### PR TITLE
Emit ordered list of related items

### DIFF
--- a/Classes/Plugins/RelatedListTool/RelatedListTool.php
+++ b/Classes/Plugins/RelatedListTool/RelatedListTool.php
@@ -146,15 +146,18 @@ class RelatedListTool extends \tx_dlf_plugin
 
             $docId = (string) $value->xpath('mods:identifier[@type="' . $type . '"]')[0];
 
+            $order = (string) $value->xpath('mods:part/@order')[0];
+
             $tempArray          = array();
             $tempArray['type']  = $type;
             $tempArray['docId'] = $docId;
             $tempArray['title'] = $title;
 
-            $relatedItems[] = $tempArray;
+            $relatedItems[$order] = $tempArray;
 
         }
 
+        ksort($relatedItems);
         return $relatedItems;
     }
 


### PR DESCRIPTION
Extracts mods:part/@order attribute from the disseminated MODS document
and uses this to sort the list of related items instead of rendering a
simple unordered list.