### PR TITLE
Don't use hash when referencing XML extension elements

### DIFF
--- a/Classes/Helper/DocumentMapper.php
+++ b/Classes/Helper/DocumentMapper.php
@@ -204,7 +204,8 @@ class DocumentMapper
                                 $modsExtensionGroupMapping = $metadataGroup->getAbsoluteModsExtensionMapping();
 
                                 $refID      = $data->getAttribute("ID");
-                                $objectData = $xpath->query($modsExtensionGroupMapping . '[@' . $referenceAttribute . '=' . '"#' . $refID . '"]/' . $objectMapping);
+                                // filter hashes from referenceAttribute value for backwards compatibility reasons
+                                $objectData = $xpath->query($modsExtensionGroupMapping . "[translate(@" . $referenceAttribute . ",'#','')=" . '"' . $refID . '"]/' . $objectMapping);
                             } else {
                                 $objectData = $xpath->query($objectMapping, $data);
                             }

--- a/Classes/Services/MetsExporter.php
+++ b/Classes/Services/MetsExporter.php
@@ -264,7 +264,7 @@ class MetsExporter
                         $existsExtensionFlag = true;
                         // mods extension
                         $counter            = sprintf("%'03d", $this->counter);
-                        $referenceAttribute = $extensionAttribute . '[@' . $group['modsExtensionReference'] . '="#QUCOSA_' . $counter . '"]';
+                        $referenceAttribute = $extensionAttribute . '[@' . $group['modsExtensionReference'] . '="QUCOSA_' . $counter . '"]';
 
                         $path = $group['modsExtensionMapping'] . $referenceAttribute . '%/' . $value['mapping'];
 
@@ -291,7 +291,7 @@ class MetsExporter
                 }
             }
             if (!$existsExtensionFlag && $group['modsExtensionMapping']) {
-                $xPath = $group['modsExtensionMapping'] . $extensionAttribute . '[@' . $group['modsExtensionReference'] . '="#QUCOSA_' . $counter . '"]';
+                $xPath = $group['modsExtensionMapping'] . $extensionAttribute . '[@' . $group['modsExtensionReference'] . '="QUCOSA_' . $counter . '"]';
                 $xml   = $this->customXPath($xPath, true, '', true);
             }
             if ($group['modsExtensionMapping']) {
@@ -905,7 +905,7 @@ class MetsExporter
                         if ($value['modsExtension']) {
                             // mods extension
                             $counter            = sprintf("%'03d", $this->counter);
-                            $referenceAttribute = '[@' . $group['modsExtensionReference'] . '="#QUCOSA_' . $counter . '"]';
+                            $referenceAttribute = '[@' . $group['modsExtensionReference'] . '="QUCOSA_' . $counter . '"]';
 
                             $path = $group['modsExtensionMapping'] . $referenceAttribute . '%/' . $value['mapping'];
 


### PR DESCRIPTION
Hashes where initially used to refer to other XML elements.

For example <mods:name ID="CORP_001"> would has been referenced via
<slub:corporation ref="#CORP_001">. This is deprecated now. To maintain
backwards compatibility with datasets using hashes in reference IDs, all
hashes must be filtered out when querying for IDs.