### PR TITLE
add CSS class "piwik_download" to DownloadTool

### DIFF
--- a/Classes/Plugins/DownloadTool/DownloadTool.php
+++ b/Classes/Plugins/DownloadTool/DownloadTool.php
@@ -85,7 +85,7 @@ class DownloadTool extends \tx_dlf_plugin
 
                 $conf = array(
                     'useCacheHash'     => 0,
-                    'parameter'        => $this->conf['apiPid'],
+                    'parameter'        => $this->conf['apiPid'] . ' - piwik_download',
                     'additionalParams' => '&tx_dpf[qid]=' . $this->doc->recordId . '&tx_dpf[action]=attachment' . '&tx_dpf[attachment]=' . $file['ID'],
                     'forceAbsoluteUrl' => true,
                 );


### PR DESCRIPTION
Links with the CSS class="piwik_download" will be detected by piwik
automatically as user action "download". Usually every PDF-file download
is detected. In case of publication this fails as the link looks like
this:

http://slub.qucosa.de/api/qucosa%3A5389/attachment/ATT-0/