### PR TITLE
show thumbnails (including PID) in flexform configuration

### DIFF
--- a/Configuration/FlexForms/frontendsearch_plugin.xml
+++ b/Configuration/FlexForms/frontendsearch_plugin.xml
@@ -1,13 +1,13 @@
 <!--
   This file is part of the TYPO3 CMS project.
- 
+
   It is free software; you can redistribute it and/or modify it under
   the terms of the GNU General Public License, either version 2
   of the License, or any later version.
- 
+
   For the full copyright and license information, please read the
   LICENSE.txt file that was distributed with this source code.
- 
+
   The TYPO3 project - inspiring people to share!
 -->
 <T3DataStructure>
@@ -52,6 +52,7 @@
                                 <size>1</size>
                                 <maxitems>1</maxitems>
                                 <minitems>0</minitems>
+                                <show_thumbs>1</show_thumbs>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>
@@ -71,6 +72,7 @@
                                 <size>1</size>
                                 <maxitems>1</maxitems>
                                 <minitems>0</minitems>
+                                <show_thumbs>1</show_thumbs>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>
@@ -90,6 +92,7 @@
                                 <size>1</size>
                                 <maxitems>1</maxitems>
                                 <minitems>0</minitems>
+                                <show_thumbs>1</show_thumbs>
                                 <wizards>
                                     <suggest>
                                         <type>suggest</type>


### PR DESCRIPTION
This patch adds a configuration to the flexorm which helps in case of multiple tenants with always the same page title. The "thumbnail" shows the page id close to the field. This makes life much easier ;-)