### PR TITLE
fixed maxDayFormMonth override

### DIFF
--- a/Classes/Controller/AbstractSearchController.php
+++ b/Classes/Controller/AbstractSearchController.php
@@ -219,7 +219,7 @@ abstract class AbstractSearchController extends \EWW\Dpf\Controller\AbstractCont
 
         $dateTime->setDate($year, $month, $day);
 
-        if ($fillMax) {
+        if ($fillMax && !isset($date[2])) {
             $maxDayFormMonth = $dateTime->format('t');
             $dateTime->setDate($year, $month, $maxDayFormMonth);
         }


### PR DESCRIPTION
@claussni This should fix results outside the entered period. $maxDayFormMonth has overridden the given $day.