### PR TITLE
Fix namespaces and method signatures for newer PHP versions

### DIFF
--- a/Classes/Controller/AbstractController.php
+++ b/Classes/Controller/AbstractController.php
@@ -27,7 +27,7 @@ abstract class AbstractController extends \TYPO3\CMS\Extbase\Mvc\Controller\Acti
      */
     protected $clientRepository = null;
 
-    protected function initializeView($view)
+    protected function initializeView(\TYPO3\CMS\Extbase\Mvc\View\ViewInterface $view)
     {
         parent::initializeView($view);
 

--- a/Classes/Controller/ClientController.php
+++ b/Classes/Controller/ClientController.php
@@ -81,7 +81,7 @@ class ClientController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
         return \TYPO3\CMS\Backend\Utility\BackendUtility::readPageAccess($pageUid, $GLOBALS['BE_USER']->getPagePermsClause(1));
     }
 
-    protected function initializeView($view)
+    protected function initializeView(\TYPO3\CMS\Extbase\Mvc\View\ViewInterface $view)
     {
         parent::initializeView($view);
 

--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -497,13 +497,13 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
                     'archive'   => $file->getArchive(),
                     'use'       => '',
                     'id'        => null,
-                    'hasFLocat' => ($file->getStatus() == \Eww\Dpf\Domain\Model\File::STATUS_ADDED ||
-                                    $file->getStatus() == \Eww\Dpf\Domain\Model\File::STATUS_CHANGED),
+                    'hasFLocat' => ($file->getStatus() == \EWW\Dpf\Domain\Model\File::STATUS_ADDED ||
+                                    $file->getStatus() == \EWW\Dpf\Domain\Model\File::STATUS_CHANGED),
                 );
 
                 $grpUSE = ($file->getDownload()) ? 'download' : 'original';
 
-                if ($file->getStatus() == \Eww\Dpf\Domain\Model\File::STATUS_DELETED) {
+                if ($file->getStatus() == \EWW\Dpf\Domain\Model\File::STATUS_DELETED) {
                     $dataStreamIdentifier = $file->getDatastreamIdentifier();
                     if (!empty($dataStreamIdentifier)) {
                         $tmpFile['id']                   = $file->getDatastreamIdentifier();
@@ -546,13 +546,13 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
                     'archive'   => $file->getArchive(),
                     'use'       => '',
                     'id'        => null,
-                    'hasFLocat' => ($file->getStatus() == \Eww\Dpf\Domain\Model\File::STATUS_ADDED ||
-                                    $file->getStatus() == \Eww\Dpf\Domain\Model\File::STATUS_CHANGED),
+                    'hasFLocat' => ($file->getStatus() == \EWW\Dpf\Domain\Model\File::STATUS_ADDED ||
+                                    $file->getStatus() == \EWW\Dpf\Domain\Model\File::STATUS_CHANGED),
                 );
 
                 $grpUSE = ($file->getDownload()) ? 'download' : 'original';
 
-                if ($file->getStatus() == \Eww\Dpf\Domain\Model\File::STATUS_DELETED) {
+                if ($file->getStatus() == \EWW\Dpf\Domain\Model\File::STATUS_DELETED) {
                     $dataStreamIdentifier = $file->getDatastreamIdentifier();
                     if (!empty($dataStreamIdentifier)) {
                         $tmpFile['id']                   = $file->getDatastreamIdentifier();

--- a/Classes/Domain/Model/DocumentFormField.php
+++ b/Classes/Domain/Model/DocumentFormField.php
@@ -100,9 +100,9 @@ class DocumentFormField extends AbstractFormElement
 
     /**
      *
-     * @param \Eww\Dpf\Domain\Model\InputOptionList $inputOptionList
+     * @param \EWW\Dpf\Domain\Model\InputOptionList $inputOptionList
      */
-    public function setInputOptions(\Eww\Dpf\Domain\Model\InputOptionList $inputOptionList = null)
+    public function setInputOptions(\EWW\Dpf\Domain\Model\InputOptionList $inputOptionList = null)
     {
 
         $this->inputOptions = array();

--- a/Classes/Domain/Model/InputOptionList.php
+++ b/Classes/Domain/Model/InputOptionList.php
@@ -1,5 +1,5 @@
 <?php
-namespace Eww\Dpf\Domain\Model;
+namespace EWW\Dpf\Domain\Model;
 
 /*
  * This file is part of the TYPO3 CMS project.

--- a/Classes/Domain/Model/MetadataObject.php
+++ b/Classes/Domain/Model/MetadataObject.php
@@ -89,7 +89,7 @@ class MetadataObject extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * inputOptionList
      *
-     * @var \Eww\Dpf\Domain\Model\InputOptionList
+     * @var \EWW\Dpf\Domain\Model\InputOptionList
      */
     protected $inputOptionList = null;
 
@@ -322,7 +322,7 @@ class MetadataObject extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Returns the inputOptionList
      *
-     * @return \Eww\Dpf\Domain\Model\InputOptionList $inputOptionList
+     * @return \EWW\Dpf\Domain\Model\InputOptionList $inputOptionList
      */
     public function getInputOptionList()
     {
@@ -332,10 +332,10 @@ class MetadataObject extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     /**
      * Sets the inputOptionList
      *
-     * @param \Eww\Dpf\Domain\Model\InputOptionList $inputOptionList
+     * @param \EWW\Dpf\Domain\Model\InputOptionList $inputOptionList
      * @return void
      */
-    public function setInputOptionList(\Eww\Dpf\Domain\Model\InputOptionList $inputOptionList)
+    public function setInputOptionList(\EWW\Dpf\Domain\Model\InputOptionList $inputOptionList)
     {
         $this->inputOptionList = $inputOptionList;
     }

--- a/Classes/Domain/Model/SysLanguage.php
+++ b/Classes/Domain/Model/SysLanguage.php
@@ -1,5 +1,5 @@
 <?php
-namespace Eww\Dpf\Domain\Model;
+namespace EWW\Dpf\Domain\Model;
 
 /*
  * This file is part of the TYPO3 CMS project.

--- a/Classes/Domain/Repository/InputOptionListRepository.php
+++ b/Classes/Domain/Repository/InputOptionListRepository.php
@@ -1,5 +1,5 @@
 <?php
-namespace Eww\Dpf\Domain\Repository;
+namespace EWW\Dpf\Domain\Repository;
 
 /*
  * This file is part of the TYPO3 CMS project.

--- a/Classes/Domain/Repository/SysLanguageRepository.php
+++ b/Classes/Domain/Repository/SysLanguageRepository.php
@@ -1,5 +1,5 @@
 <?php
-namespace Eww\Dpf\Domain\Repository;
+namespace EWW\Dpf\Domain\Repository;
 
 /*
  * This file is part of the TYPO3 CMS project.
@@ -23,7 +23,7 @@ class SysLanguageRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     /**
      * Finds all installed languages of the TYPO3 system (usually on pid 0).
      *
-     * @return \EWW\dpf\Domain\Model\SysLanguage | NULL
+     * @return \EWW\Dpf\Domain\Model\SysLanguage | NULL
      */
     public function findInstalledLanguages()
     {
@@ -34,7 +34,7 @@ class SysLanguageRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
         if ($result->execute()) {
             foreach ($result->execute() as $language) {
-                $sysLanguage = new \EWW\dpf\Domain\Model\SysLanguage();
+                $sysLanguage = new \EWW\Dpf\Domain\Model\SysLanguage();
                 $sysLanguage->setUid($language['uid']);
                 $sysLanguage->setPid($language['pid']);
                 $sysLanguage->setTitle($language['title']);


### PR DESCRIPTION
The commits solve two problems:
- PHP namespaces use different upper and lower cases, e.g. ' \EWW' vs. '\Eww'
- The type hints of at least to inherited methods don't match the parent classes methods' type hints

This resulted in errors on PHP 7.1 (and probably already on earlier versions).