### PR TITLE
fix #66: change wizard registration in TCA

### DIFF
--- a/Configuration/TCA/MetadataPage.php
+++ b/Configuration/TCA/MetadataPage.php
@@ -11,7 +11,7 @@
  *
  * The TYPO3 project - inspiring people to share!
  */
- 
+
 if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
@@ -170,7 +170,9 @@ $GLOBALS['TCA']['tx_dpf_domain_model_metadatapage'] = array(
                     'edit'      => array(
                         'type'                     => 'popup',
                         'title'                    => 'Edit',
-                        'script'                   => 'wizard_edit.php',
+                        'module' => array(
+                          'name' => 'wizard_edit',
+                        ),
                         'icon'                     => 'edit2.gif',
                         'popup_onlyOpenIfSelected' => 1,
                         'JSopenParams'             => 'height=350,width=580,status=0,menubar=0,scrollbars=1',
@@ -184,7 +186,9 @@ $GLOBALS['TCA']['tx_dpf_domain_model_metadatapage'] = array(
                             'pid'      => '###CURRENT_PID###',
                             'setValue' => 'prepend',
                         ),
-                        'script' => 'wizard_add.php',
+                        'module' => array(
+                          'name' => 'wizard_add',
+                        ),
                     ),
                 ),
             ),


### PR DESCRIPTION
This fixes the following notice in the deprecation.log:

> The way registering a wizard in TCA has changed in 6.2. Please set module[name]=module_name instead of using script=path/to/script.php in your TCA. The possibility to register wizards this way will be removed in TYPO3 CMS 7.
