### PR TITLE
Configurable forbidden API actions

### DIFF
--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -72,6 +72,11 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
 
         $fedoraHost = $this->clientConfigurationManager->getFedoraHost();
 
+        if ($this->isForbidden($piVars['action'])) {
+            $this->response->setStatus(403);
+            return 'Forbidden';
+        }
+
         switch ($piVars['action']) {
             case 'mets':
                 $path = rtrim('http://' . $fedoraHost,"/").'/fedora/objects/'.$piVars['qid'].'/methods/qucosa:SDef/getMETSDissemination?supplement=yes';
@@ -268,6 +273,15 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
         $metsXml = $exporter->getMetsData();
 
         return $metsXml;
+    }
+
+    private function isForbidden($action)
+    {
+        $allowed =
+            array_key_exists('allowedActions', $this->settings)
+            && is_array($this->settings['allowedActions'])
+            && in_array($action, $this->settings['allowedActions']);
+        return !$allowed;
     }
 }
 

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -27,6 +27,11 @@ plugin.tx_dpf {
 	}
 
         settings {
+			api {
+				# cat=plugin.tx_dpf/api; type=string; label=Comma separated list of hosts allowed to access internal actions
+				allowedHosts = localhost
+			}
+
             defaultValue {
                 fullTextLabel = Volltext (PDF)
             }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -56,6 +56,17 @@ plugin.tx_dpf {
         }
 }
 
+# Actions, only allowed for developers and localhost
+[IP=devIP][hostname={$plugin.tx_dpf.settings.api.allowedHosts}]
+	plugin.tx_dpf.settings.allowedActions {
+		1 = mets
+		2 = preview
+		3 = dataCite
+	}
+[end]
+
+# Action which is always allowed
+plugin.tx_dpf.settings.allowedActions.4 = attachment
 
 plugin.tx_dpf._CSS_DEFAULT_STYLE (
 	textarea.f3-form-error {


### PR DESCRIPTION
The plugins API controller checks for a setting called
`forbiddenActions`. This setting should be an array of actions that
should be forbidden for the given request.

This setting can be set using TYPOScript conditions in the page setup, e.g.:

[!IP=devIP] && [!hostname=my-internal-host]
    plugin.tx_dpf.settings.forbiddenActions.1 = mets
[end]

The action will respond with 403 Forbidden to any request to actions
listed in the array.