### PR TITLE
Avoid HTML5 date picker for date fields

### DIFF
--- a/Resources/Private/Templates/SearchFE/ExtendedSearch.html
+++ b/Resources/Private/Templates/SearchFE/ExtendedSearch.html
@@ -68,11 +68,11 @@
 					<div class="col-md-6" style="padding:0px;">
 						<div class="form-group">
 							<label for="from">{f:translate(key: 'search.form.label.date')}</label>
-							<f:form.textfield property="from" type="date" class="form-control datetimepicker"
+							<f:form.textfield property="from" type="text" class="form-control datetimepicker"
 								placeholder="{f:translate(key: 'search.form.label.from')}" id="from"
 								value="{query.from}"/>
 							<label for="till">{f:translate(key: 'search.form.label.to')}</label>
-							<f:form.textfield property="till" type="date" class="form-control datetimepicker"
+							<f:form.textfield property="till" type="text" class="form-control datetimepicker"
 								placeholder="{f:translate(key: 'search.form.label.to')}" id="till"
 								value="{query.till}"/>
 						</div>


### PR DESCRIPTION
HTML5 supports type="date" for input fields. Some browser provide native date picker which conflict with old-style JavaScript date picker widgets.

Resolves https://jira.slub-dresden.de/browse/CMR-385