### PR TITLE
Overwrite backend layouts as of TYPO3 7.6

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -16,9 +16,9 @@ plugin.tx_dpf {
 		callDefaultActionIfActionCantBeResolved = 1
 	}
 	view {
-		templateRootPath = {$plugin.tx_dpf.view.templateRootPath}
-		partialRootPath = {$plugin.tx_dpf.view.partialRootPath}
-		layoutRootPath = {$plugin.tx_dpf.view.layoutRootPath}
+		templateRootPaths.10 = {$plugin.tx_dpf.view.templateRootPath}
+		partialRootPaths.10 = {$plugin.tx_dpf.view.partialRootPath}
+		layoutRootPaths.10 = {$plugin.tx_dpf.view.layoutRootPath}
 	}
 	persistence {
 		storagePid = {$plugin.tx_dpf.persistence.storagePid}
@@ -138,9 +138,9 @@ module.tx_dpf {
                 recursive = {$module.tx_dpf.persistence.recursive}
 	}
 	view {
-		templateRootPath = {$module.tx_dpf.view.templateRootPath}
-		partialRootPath = {$module.tx_dpf.view.partialRootPath}
-		layoutRootPath = {$module.tx_dpf.view.layoutRootPath}
+		templateRootPaths.10 = {$module.tx_dpf.view.templateRootPath}
+		partialRootPaths.10 = {$module.tx_dpf.view.partialRootPath}
+		layoutRootPaths.10 = {$module.tx_dpf.view.layoutRootPath}
 	}
 
 
@@ -153,3 +153,6 @@ module.tx_dpf {
         }
 }
 
+[compatVersion = 7.6.0]
+module.tx_dpf.view.layoutRootPaths.100 = EXT:dpf/Resources/Private/Layouts76/
+[global]

--- a/Resources/Private/Layouts/DefaultBE.html
+++ b/Resources/Private/Layouts/DefaultBE.html
@@ -18,36 +18,13 @@
 <f:be.container loadPrototype="false" loadScriptaculous="false" enableClickMenu="false"
                 includeCssFiles="{0: '{f:uri.resource(path:\'CSS/bootstrap.min.css\')}',1: '{f:uri.resource(path:\'CSS/manager.css\')}'}"
                 includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/jQuery.min.js\')}',1: '{f:uri.resource(path:\'JavaScript/moment-with-locales.min.js\')}',2: '{f:uri.resource(path:\'JavaScript/bootstrap.min.js\')}',3: '{f:uri.resource(path:\'JavaScript/bootstrap-datetimepicker.min.js\')}',4: '{f:uri.resource(path:\'JavaScript/qucosa.js\')}'}">
+
     <div class="tx-dpf" data-language="{dpf:language()}">
-        <f:comment>
-            <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
-        </f:comment>
-        <p class="bg-info client">{f:translate(key: 'manager.client')}: <strong>{client.client}</strong></p>
 
-        <f:be.menus.actionMenu>
-            <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.documents')}" controller="Document"
-                                       action="list"/>
-            <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.search')}" controller="Search"
-                                       action="list"/>
-        </f:be.menus.actionMenu>
-
-        <div class="be-page-header">
-            <div class="btn-group controller-switch" role="group">
-                <f:link.action action="list" controller="Document"
-                               class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document')}">
-                    <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
-                    {f:translate(key: 'manager.control.documents')}
-                </f:link.action>
-                <f:link.action action="list" controller="Search"
-                               class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Search')}">
-                    <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
-                    {f:translate(key: 'manager.control.search')}
-                </f:link.action>
-            </div>
-        </div>
-
-        <f:flashMessages renderMode="div"/>
+        <f:render partial="Layouts/DefaultBE" arguments="{_all}" />
 
         <f:render section="main"/>
+
     </div>
+
 </f:be.container>

--- a/Resources/Private/Layouts/DocumentBE.html
+++ b/Resources/Private/Layouts/DocumentBE.html
@@ -18,19 +18,13 @@
 <f:be.container loadPrototype="false" loadScriptaculous="false" enableClickMenu="false"
                 includeCssFiles="{0: '{f:uri.resource(path:\'CSS/qucosa.css\')}',1: '{f:uri.resource(path:\'CSS/qucosabe.css\')}'}"
                 includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/jQuery.min.js\')}',1: '{f:uri.resource(path:\'JavaScript/moment-with-locales.min.js\')}',2: '{f:uri.resource(path:\'JavaScript/bootstrap.min.js\')}',3: '{f:uri.resource(path:\'JavaScript/bootstrap-datetimepicker.min.js\')}',4: '{f:uri.resource(path:\'JavaScript/qucosa.js\')}'}">
-    <div class="tx-dpf" data-language="{dpf:language()}">
-        <f:comment>
-            <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
-        </f:comment>
 
-        <script type="text/javascript">
-            var form_error_msg_group_mandatory = '<f:translate key="form_error_msg.group_mandatory" default="Please fill in the required fields." />';
-            var form_error_msg_group_one_required = '<f:translate key="form_error_msg.group_one_required"  default="Please fill out at least one of the fields." />';
-            var form_error_msg_field_invalid = '<f:translate key="form_error_msg.field_invalid" default="Invalid input" />';
-            var form_error_msg = '<f:translate key="form_error_msg.all" default="The form contains errors."/>';
-            var form_success_msg = '<f:translate key="form_success_msg.all" default="Form successfully validated."/>';
-        </script>
+    <div class="tx-dpf" data-language="{dpf:language()}">
+
+        <f:render partial="Layouts/DocumentBE" arguments="{_all}" />
 
         <f:render section="main"/>
+
     </div>
+
 </f:be.container>

--- a/Resources/Private/Layouts76/DefaultBE.html
+++ b/Resources/Private/Layouts76/DefaultBE.html
@@ -18,36 +18,13 @@
 <f:be.container enableClickMenu="false"
                 includeCssFiles="{0: '{f:uri.resource(path:\'CSS/bootstrap.min.css\')}',1: '{f:uri.resource(path:\'CSS/manager.css\')}'}"
                 includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/jQuery.min.js\')}',1: '{f:uri.resource(path:\'JavaScript/moment-with-locales.min.js\')}',2: '{f:uri.resource(path:\'JavaScript/bootstrap.min.js\')}',3: '{f:uri.resource(path:\'JavaScript/bootstrap-datetimepicker.min.js\')}',4: '{f:uri.resource(path:\'JavaScript/qucosa.js\')}'}">
+
     <div class="tx-dpf" data-language="{dpf:language()}">
-        <f:comment>
-            <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
-        </f:comment>
-        <p class="bg-info client">{f:translate(key: 'manager.client')}: <strong>{client.client}</strong></p>
 
-        <f:be.menus.actionMenu>
-            <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.documents')}" controller="Document"
-                                       action="list"/>
-            <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.search')}" controller="Search"
-                                       action="list"/>
-        </f:be.menus.actionMenu>
-
-        <div class="be-page-header">
-            <div class="btn-group controller-switch" role="group">
-                <f:link.action action="list" controller="Document"
-                               class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document')}">
-                    <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
-                    {f:translate(key: 'manager.control.documents')}
-                </f:link.action>
-                <f:link.action action="list" controller="Search"
-                               class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Search')}">
-                    <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
-                    {f:translate(key: 'manager.control.search')}
-                </f:link.action>
-            </div>
-        </div>
-
-        <f:flashMessages renderMode="div"/>
+        <f:render partial="Layouts/DefaultBE" arguments="{_all}" />
 
         <f:render section="main"/>
+
     </div>
+
 </f:be.container>

--- a/Resources/Private/Layouts76/DefaultBE.html
+++ b/Resources/Private/Layouts76/DefaultBE.html
@@ -1,0 +1,53 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+
+{namespace dpf=EWW\Dpf\ViewHelpers}
+
+<f:be.container enableClickMenu="false"
+                includeCssFiles="{0: '{f:uri.resource(path:\'CSS/bootstrap.min.css\')}',1: '{f:uri.resource(path:\'CSS/manager.css\')}'}"
+                includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/jQuery.min.js\')}',1: '{f:uri.resource(path:\'JavaScript/moment-with-locales.min.js\')}',2: '{f:uri.resource(path:\'JavaScript/bootstrap.min.js\')}',3: '{f:uri.resource(path:\'JavaScript/bootstrap-datetimepicker.min.js\')}',4: '{f:uri.resource(path:\'JavaScript/qucosa.js\')}'}">
+    <div class="tx-dpf" data-language="{dpf:language()}">
+        <f:comment>
+            <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
+        </f:comment>
+        <p class="bg-info client">{f:translate(key: 'manager.client')}: <strong>{client.client}</strong></p>
+
+        <f:be.menus.actionMenu>
+            <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.documents')}" controller="Document"
+                                       action="list"/>
+            <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.search')}" controller="Search"
+                                       action="list"/>
+        </f:be.menus.actionMenu>
+
+        <div class="be-page-header">
+            <div class="btn-group controller-switch" role="group">
+                <f:link.action action="list" controller="Document"
+                               class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document')}">
+                    <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+                    {f:translate(key: 'manager.control.documents')}
+                </f:link.action>
+                <f:link.action action="list" controller="Search"
+                               class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Search')}">
+                    <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+                    {f:translate(key: 'manager.control.search')}
+                </f:link.action>
+            </div>
+        </div>
+
+        <f:flashMessages renderMode="div"/>
+
+        <f:render section="main"/>
+    </div>
+</f:be.container>

--- a/Resources/Private/Layouts76/DocumentBE.html
+++ b/Resources/Private/Layouts76/DocumentBE.html
@@ -18,19 +18,13 @@
 <f:be.container enableClickMenu="false"
                 includeCssFiles="{0: '{f:uri.resource(path:\'CSS/qucosa.css\')}',1: '{f:uri.resource(path:\'CSS/qucosabe.css\')}'}"
                 includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/jQuery.min.js\')}',1: '{f:uri.resource(path:\'JavaScript/moment-with-locales.min.js\')}',2: '{f:uri.resource(path:\'JavaScript/bootstrap.min.js\')}',3: '{f:uri.resource(path:\'JavaScript/bootstrap-datetimepicker.min.js\')}',4: '{f:uri.resource(path:\'JavaScript/qucosa.js\')}'}">
-    <div class="tx-dpf" data-language="{dpf:language()}">
-        <f:comment>
-            <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
-        </f:comment>
 
-        <script type="text/javascript">
-            var form_error_msg_group_mandatory = '<f:translate key="form_error_msg.group_mandatory" default="Please fill in the required fields." />';
-            var form_error_msg_group_one_required = '<f:translate key="form_error_msg.group_one_required"  default="Please fill out at least one of the fields." />';
-            var form_error_msg_field_invalid = '<f:translate key="form_error_msg.field_invalid" default="Invalid input" />';
-            var form_error_msg = '<f:translate key="form_error_msg.all" default="The form contains errors."/>';
-            var form_success_msg = '<f:translate key="form_success_msg.all" default="Form successfully validated."/>';
-        </script>
+    <div class="tx-dpf" data-language="{dpf:language()}">
+
+        <f:render partial="Layouts/DocumentBE" arguments="{_all}" />
 
         <f:render section="main"/>
+
     </div>
+
 </f:be.container>

--- a/Resources/Private/Layouts76/DocumentBE.html
+++ b/Resources/Private/Layouts76/DocumentBE.html
@@ -1,0 +1,36 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+
+{namespace dpf=EWW\Dpf\ViewHelpers}
+
+<f:be.container enableClickMenu="false"
+                includeCssFiles="{0: '{f:uri.resource(path:\'CSS/qucosa.css\')}',1: '{f:uri.resource(path:\'CSS/qucosabe.css\')}'}"
+                includeJsFiles="{0: '{f:uri.resource(path:\'JavaScript/jQuery.min.js\')}',1: '{f:uri.resource(path:\'JavaScript/moment-with-locales.min.js\')}',2: '{f:uri.resource(path:\'JavaScript/bootstrap.min.js\')}',3: '{f:uri.resource(path:\'JavaScript/bootstrap-datetimepicker.min.js\')}',4: '{f:uri.resource(path:\'JavaScript/qucosa.js\')}'}">
+    <div class="tx-dpf" data-language="{dpf:language()}">
+        <f:comment>
+            <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
+        </f:comment>
+
+        <script type="text/javascript">
+            var form_error_msg_group_mandatory = '<f:translate key="form_error_msg.group_mandatory" default="Please fill in the required fields." />';
+            var form_error_msg_group_one_required = '<f:translate key="form_error_msg.group_one_required"  default="Please fill out at least one of the fields." />';
+            var form_error_msg_field_invalid = '<f:translate key="form_error_msg.field_invalid" default="Invalid input" />';
+            var form_error_msg = '<f:translate key="form_error_msg.all" default="The form contains errors."/>';
+            var form_success_msg = '<f:translate key="form_success_msg.all" default="Form successfully validated."/>';
+        </script>
+
+        <f:render section="main"/>
+    </div>
+</f:be.container>

--- a/Resources/Private/Partials/Layouts/DefaultBE.html
+++ b/Resources/Private/Partials/Layouts/DefaultBE.html
@@ -1,0 +1,45 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+
+{namespace dpf=EWW\Dpf\ViewHelpers}
+
+<f:comment>
+    <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
+</f:comment>
+<p class="bg-info client">{f:translate(key: 'manager.client')}: <strong>{client.client}</strong></p>
+
+<f:be.menus.actionMenu>
+    <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.documents')}" controller="Document"
+                               action="list"/>
+    <f:be.menus.actionMenuItem label="{f:translate(key: 'manager.control.search')}" controller="Search"
+                               action="list"/>
+</f:be.menus.actionMenu>
+
+<div class="be-page-header">
+    <div class="btn-group controller-switch" role="group">
+        <f:link.action action="list" controller="Document"
+                       class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document')}">
+            <span class="glyphicon glyphicon-file" aria-hidden="true"></span>
+            {f:translate(key: 'manager.control.documents')}
+        </f:link.action>
+        <f:link.action action="list" controller="Search"
+                       class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Search')}">
+            <span class="glyphicon glyphicon-search" aria-hidden="true"></span>
+            {f:translate(key: 'manager.control.search')}
+        </f:link.action>
+    </div>
+</div>
+
+<f:flashMessages renderMode="div"/>

--- a/Resources/Private/Partials/Layouts/DocumentBE.html
+++ b/Resources/Private/Partials/Layouts/DocumentBE.html
@@ -1,0 +1,28 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+
+{namespace dpf=EWW\Dpf\ViewHelpers}
+
+<f:comment>
+    <f:debug title="Debug" maxDepth="20">{debugData}</f:debug>
+</f:comment>
+
+<script type="text/javascript">
+    var form_error_msg_group_mandatory = '<f:translate key="form_error_msg.group_mandatory" default="Please fill in the required fields." />';
+    var form_error_msg_group_one_required = '<f:translate key="form_error_msg.group_one_required"  default="Please fill out at least one of the fields." />';
+    var form_error_msg_field_invalid = '<f:translate key="form_error_msg.field_invalid" default="Invalid input" />';
+    var form_error_msg = '<f:translate key="form_error_msg.all" default="The form contains errors."/>';
+    var form_success_msg = '<f:translate key="form_success_msg.all" default="Form successfully validated."/>';
+</script>


### PR DESCRIPTION
By the configured typoscript condition the path to backend layouts gets
overwritten for TYPO3 >=7.6.

Using the plural constants for templateRootPath(s), partialRootPath(s)
and layoutRootPath(s) makes it possible to have a fallback. All
templates which does not exist in highest numbered folder are search in
the next lower.

-->

module.tx_dpf.view.layoutRootPaths.100 overwrites
module.tx_dpf.view.layoutRootPaths.10

But e.g. AdminBE.html which is not present in layoutRootPaths.100 will
be searched in layoutRootPaths.10.

This feature exists as of TYPO3 6.2.