### PR TITLE
Fix #77 - replace conditional viewhelpers 

### DIFF
--- a/Classes/ViewHelpers/GetTypo3ModeViewHelper.php
+++ b/Classes/ViewHelpers/GetTypo3ModeViewHelper.php
@@ -1,0 +1,28 @@
+<?php
+namespace EWW\Dpf\ViewHelpers;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+class GetTypo3ModeViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
+{
+
+    /**
+      * @return string
+     */
+    public function render()
+    {
+        return TYPO3_MODE;
+    }
+
+}

--- a/Classes/ViewHelpers/IsConsentFieldViewHelper.php
+++ b/Classes/ViewHelpers/IsConsentFieldViewHelper.php
@@ -14,7 +14,7 @@ namespace EWW\Dpf\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-class IsConsentFieldViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper
+class IsConsentFieldViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
 
     /**
@@ -25,9 +25,9 @@ class IsConsentFieldViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\Abstract
     public function render($condition)
     {
         if ((TYPO3_MODE === 'BE') && $condition) {
-            return $this->renderThenChild();
+            return TRUE;
         }
-        return $this->renderElseChild();
+        return FALSE;
     }
 
 }

--- a/Classes/ViewHelpers/IsElementAllowedViewHelper.php
+++ b/Classes/ViewHelpers/IsElementAllowedViewHelper.php
@@ -14,7 +14,7 @@ namespace EWW\Dpf\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
-class IsElementAllowedViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper
+class IsElementAllowedViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
 
     /**
@@ -25,9 +25,9 @@ class IsElementAllowedViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\Abstra
     public function render($condition)
     {
         if ((TYPO3_MODE === 'BE') || !$condition) {
-            return $this->renderThenChild();
+            return TRUE;
         }
-        return $this->renderElseChild();
+        return FALSE;
     }
 
 }

--- a/Resources/Private/Partials/DocumentForm/Field.html
+++ b/Resources/Private/Partials/DocumentForm/Field.html
@@ -62,7 +62,7 @@
             </div>
         </f:case>
         <f:case value="3">
-            <eww:isConsentField condition="{fieldItem.consent}">
+            <f:if condition="{eww:IsConsentField(condition:'{fieldItem.consent}')}">
                 <f:then>
                     <f:form.checkbox id="inp_{fieldItem.uid}"
                                      property="metadata.{formPageUid}-{formGroupUid}-{groupIndex}-{fieldItem.uid}-{fieldIndex}"
@@ -80,7 +80,7 @@
                                      additionalAttributes="{data-field:fieldItem.uid,data-index:fieldIndex,data-mandatory:fieldItem.mandatory,data-group:formGroupUid,data-groupindex:groupIndex,data-default:fieldItem.hasDefaultValue,data-regexp:fieldItem.validation,data-datatype:fieldItem.dataType,data-label:fieldItem.displayName}"
                                      checked="{fieldItem.value}"/>
                 </f:else>
-            </eww:isConsentField>
+            </f:if>
         </f:case>
     </f:switch>
 
@@ -110,5 +110,3 @@
         </f:for>
     </f:if>
 </f:form.validationResults>
-
-

--- a/Resources/Private/Partials/DocumentForm/FormBody.html
+++ b/Resources/Private/Partials/DocumentForm/FormBody.html
@@ -19,12 +19,12 @@
 <div class="tx-dpf-tab-container">
     <ul class="tx-dpf-tabs nav nav-tabs">
         <f:for each="{documentForm.items}" as="formPage" iteration="pageIterator">
-            <eww:isElementAllowed condition="{formPage.0.backendOnly}">
+            <f:if condition="{eww:IsElementAllowed(condition:'{formPage.0.backendOnly}')}">
                 <f:then>
                     <li class="{f:if(condition: '{pageIterator.index}==0', then: 'active', else:'')}">
                         <a href="#tab-{pageIterator.cycle}" data-toggle="tab">{formPage.0.displayName}</a></li>
                 </f:then>
-            </eww:isElementAllowed>
+            </f:if>
         </f:for>
         <li><a href="#tab-file-upload" data-toggle="tab">Dateien</a></li>
     </ul>
@@ -32,14 +32,14 @@
 
 <div class="tab-content">
     <f:for each="{documentForm.items}" as="formPage" iteration="pageIterator">
-        <eww:isElementAllowed condition="{formPage.0.backendOnly}">
+        <f:if condition="{eww:IsElementAllowed(condition:'{formPage.0.backendOnly}')}">
             <f:then>
                 <div id="tab-{pageIterator.cycle}"
                      class="fs_page tab-pane {f:if(condition: '{pageIterator.index}==0', then: 'active', else:'')}"
                      data-page="{formPage.0.uid}">
                     <f:for each="{formPage.0.items}" as="formGroup" iteration="groupIterator">
                         <f:for each="{formGroup}" as="groupItem" iteration="groupItemIterator">
-                            <eww:isElementAllowed condition="{groupItem.backendOnly}">
+                            <f:if condition="{eww:IsElementAllowed(condition:'{groupItem.backendOnly}')}">
                                 <f:then>
                                     <f:render partial="DocumentForm/Group"
                                               arguments="{formPageUid:formPage.0.uid,formGroupUid:groupItem.uid,formGroupDisplayName:groupItem.displayName,groupItem:groupItem,groupIndex:groupItemIterator.index}"/>
@@ -57,12 +57,12 @@
                                         </f:if>
                                     </f:if>
                                 </f:then>
-                            </eww:isElementAllowed>
+                            </f:if>
                         </f:for>
                     </f:for>
                 </div>
             </f:then>
-        </eww:isElementAllowed>
+        </f:if>
     </f:for>
 
     <div id="tab-file-upload" class="fs_page tab-pane">

--- a/Resources/Private/Partials/DocumentForm/Group.html
+++ b/Resources/Private/Partials/DocumentForm/Group.html
@@ -32,7 +32,7 @@
             <f:if condition="{fieldItem.inputField}!=4">
                 <f:then>
                     <div class="form-container {f:if(condition: '{fieldItem.dataType} == \'DATE\'', then: 'hasDatepicker', else: '')}">
-                        <eww:isElementAllowed condition="{fieldItem.backendOnly}">
+                        <f:if condition="{eww:IsElementAllowed(condition:'{fieldItem.backendOnly}')}">
                             <f:then>
                                 <f:render partial="DocumentForm/Field"
                                           arguments="{formPageUid: formPageUid,formGroupUid: formGroupUid,groupIndex: groupIndex,formField: formField,fieldIndex: fieldItemIterator.index,fieldItem: fieldItem,countries: countries}"/>
@@ -49,7 +49,7 @@
                                     </f:if>
                                 </f:if>
                             </f:then>
-                        </eww:isElementAllowed>
+                        </f:if>
                     </div>
                 </f:then>
                 <f:else>

--- a/Resources/Private/Partials/DocumentForm/PrimaryFileGroup.html
+++ b/Resources/Private/Partials/DocumentForm/PrimaryFileGroup.html
@@ -28,8 +28,7 @@
                     {f:translate(key: 'form_button.remove_file', arguments: {0: ''})}
                 </button>
             </div>
-
-            <eww:isElementAllowed condition="backendOnly">
+            <f:if condition="{eww:getTypo3Mode()} == 'BE'">
                 <f:then>
                     <div class="form-group">
                         <label for="inp_primFile_label_{file.uid}" data-index="{groupIndex}">Display name</label>
@@ -50,7 +49,7 @@
                                          checked="{file.archive}"/>
                     </div>
                 </f:then>
-            </eww:isElementAllowed>
+            </f:if>
         </fieldset>
     </f:then>
     <f:else>

--- a/Resources/Private/Partials/DocumentForm/PrimaryUpload.html
+++ b/Resources/Private/Partials/DocumentForm/PrimaryUpload.html
@@ -22,7 +22,7 @@
         <span class="glyphicon glyphicon-trash"></span>
         {f:translate(key: 'form_button.remove_file', arguments: {0: ''})}
     </button>
-    <eww:isElementAllowed condition="backendOnly">
+    <f:if condition="{eww:getTypo3Mode()} == 'BE'">
         <f:then>
             <div class="form-group">
                 <label for="inp_primaryFile" data-index="{}">Display name</label>
@@ -42,6 +42,5 @@
                                  checked="{file.archive}"/>
             </div>
         </f:then>
-    </eww:isElementAllowed>
+    </f:if>
 </fieldset>
-

--- a/Resources/Private/Partials/DocumentForm/SecondaryFileGroup.html
+++ b/Resources/Private/Partials/DocumentForm/SecondaryFileGroup.html
@@ -36,7 +36,7 @@
                     <!--</button>-->
                 </div>
 
-                <eww:isElementAllowed condition="backendOnly">
+                <f:if condition="{eww:getTypo3Mode()} == 'BE'">
                     <f:then>
                         <div class="form-group">
                             <label for="inp_secFiles_label_{file.uid}" data-index="{groupIndex}">Display name</label>
@@ -58,7 +58,7 @@
                                              additionalAttributes="{}" checked="{file.archive}"/>
                         </div>
                     </f:then>
-                </eww:isElementAllowed>
+                </f:if>
             </fieldset>
         </f:for>
     </f:then>

--- a/Resources/Private/Partials/DocumentForm/SecondaryUpload.html
+++ b/Resources/Private/Partials/DocumentForm/SecondaryUpload.html
@@ -22,7 +22,7 @@
         {f:translate(key: 'form_button.remove_file' arguments: {0: ''})}
     </button>
 
-    <eww:isElementAllowed condition="backendOnly">
+    <f:if condition="{eww:getTypo3Mode()} == 'BE'">
         <f:then>
             <div class="form-group">
                 <label for="inp_secondaryFile_{groupIndex}" data-index="{groupIndex}">Display name</label>
@@ -42,5 +42,5 @@
                                  checked="{file.archive}"/>
             </div>
         </f:then>
-    </eww:isElementAllowed>
+    </f:if>
 </fieldset>


### PR DESCRIPTION
This patch replaces the conditional viewhelpers by normal ones. It adds a new viewhelper "getTypo3Mode" to have access to the TYPO3_MODE constant in fluid and render certain parts only in case of backend context (TYPO3_MODE=='BE').

This should work in TYPO3 6.2 and 7.6.