### PR TITLE
Add ZIP download action to API

### DIFF
--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -169,6 +169,12 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
 
                 break;
 
+            case 'zip':
+                // FIXME Service locations on Fedora host are hard coded
+                $metsUrl = rtrim('http://' . $fedoraHost,"/") . '/mets?pid=' . $piVars['qid'];
+                $path = rtrim('http://' . $fedoraHost,"/") . '/zip?metsurl=' . rawurlencode($metsUrl);
+                break;
+
             default:
 
                 $this->response->setStatus(404);

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -1,13 +1,13 @@
 # -------------------------------------------------------------------
 # This file is part of the TYPO3 CMS project.
-# 
+#
 # It is free software; you can redistribute it and/or modify it under
 # the terms of the GNU General Public License, either version 2
 # of the License, or any later version.
-# 
+#
 # For the full copyright and license information, please read the
 # LICENSE.txt file that was distributed with this source code.
-# 
+#
 # The TYPO3 project - inspiring people to share!
 # -------------------------------------------------------------------
 
@@ -67,6 +67,7 @@ plugin.tx_dpf {
 
 # Action which is always allowed
 plugin.tx_dpf.settings.allowedActions.4 = attachment
+plugin.tx_dpf.settings.allowedActions.5 = zip
 
 plugin.tx_dpf._CSS_DEFAULT_STYLE (
 	textarea.f3-form-error {


### PR DESCRIPTION
Extends API (GetFileController.php) with a `zip` endpoint which allows
access to zip container files. This is used in OAI XMetaDissPlus
harvesting format.

Resolves https://jira.slub-dresden.de/browse/CMR-389