### PR TITLE
fix #78: replace all instantiation strings by new PHP (>5.5) "::class" notation

### DIFF
--- a/Classes/Command/TransferCommandController.php
+++ b/Classes/Command/TransferCommandController.php
@@ -38,8 +38,6 @@ class TransferCommandController extends \TYPO3\CMS\Extbase\Mvc\Controller\Comman
 
         $success = true;
 
-        $repository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\FedoraRepository');
-
         return true;
     }
 }

--- a/Classes/Configuration/ClientConfigurationManager.php
+++ b/Classes/Configuration/ClientConfigurationManager.php
@@ -14,7 +14,12 @@ namespace EWW\Dpf\Configuration;
  * The TYPO3 project - inspiring people to share!
  */
 
-class ClientConfigurationManager 
+use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use EWW\Dpf\Domain\Repository\ClientRepository;
+
+class ClientConfigurationManager
 {
 
 	/**
@@ -54,11 +59,11 @@ class ClientConfigurationManager
      * @var array
      */
     protected $extensionConfiguration = array();
-   
+
     public function __construct()
     {
-    	$objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $clientRepository = $objectManager->get("EWW\\Dpf\\Domain\\Repository\\ClientRepository");
+        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $clientRepository = $objectManager->get(ClientRepository::class);
 
 		if (TYPO3_MODE === 'BE')
 		{
@@ -67,7 +72,7 @@ class ClientConfigurationManager
             {
                 $this->client = $clientRepository->findAll()->current();
 
-                $configurationManager = $objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\BackendConfigurationManager');
+                $configurationManager = $objectManager->get(BackendConfigurationManager::class);
                 $settings = $configurationManager->getConfiguration(NULL,NULL);
                 $this->settings = $settings; //['settings'];
             }
@@ -77,7 +82,7 @@ class ClientConfigurationManager
 		{
             $this->client = $clientRepository->findAll()->current();
 
-    		$configurationManager = $objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager');
+            $configurationManager = $objectManager->get(ConfigurationManager::class);
     		$this->settings = $configurationManager->getConfiguration(
             	\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS
         	);

--- a/Classes/Controller/AbstractDocumentFormController.php
+++ b/Classes/Controller/AbstractDocumentFormController.php
@@ -14,6 +14,13 @@ namespace EWW\Dpf\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EWW\Dpf\Domain\Model\Document;
+use EWW\Dpf\Services\Email\Notifier;
+use EWW\Dpf\Services\Transfer\ElasticsearchRepository;
+use EWW\Dpf\Helper\DocumentMapper;
+use EWW\Dpf\Helper\ElasticsearchMapper;
+use EWW\Dpf\Helper\FormDataReader;
+
 /**
  * DocumentFormController
  */
@@ -144,9 +151,9 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
         } elseif (array_key_exists('documentType', $requestArguments)) {
             $docTypeUid   = $this->request->getArgument('documentType');
             $documentType = $this->documentTypeRepository->findByUid($docTypeUid);
-            $document     = $this->objectManager->get('\EWW\Dpf\Domain\Model\Document');
+            $document     = $this->objectManager->get(Document::class);
             $document->setDocumentType($documentType);
-            $mapper  = $this->objectManager->get('EWW\Dpf\Helper\DocumentMapper');
+            $mapper  = $this->objectManager->get(DocumentMapper::class);
             $docForm = $mapper->getDocumentForm($document);
         } elseif (array_key_exists('newDocumentForm', $requestArguments)) {
             $docForm = $this->request->getArgument('newDocumentForm');
@@ -176,7 +183,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
         if ($this->request->hasArgument('documentData')) {
             $documentData = $this->request->getArgument('documentData');
 
-            $formDataReader = $this->objectManager->get('EWW\Dpf\Helper\FormDataReader');
+            $formDataReader = $this->objectManager->get(FormDataReader::class);
             $formDataReader->setFormData($documentData);
 
             $docForm                             = $formDataReader->getDocumentForm();
@@ -206,7 +213,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
     public function createAction(\EWW\Dpf\Domain\Model\DocumentForm $newDocumentForm)
     {
 
-        $documentMapper = $this->objectManager->get('EWW\Dpf\Helper\DocumentMapper');
+        $documentMapper = $this->objectManager->get(DocumentMapper::class);
         $newDocument    = $documentMapper->getDocument($newDocumentForm);
 
         $this->documentRepository->add($newDocument);
@@ -230,7 +237,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
             }
         }
 
-        $notifier = $this->objectManager->get('\EWW\Dpf\Services\Email\Notifier');
+        $notifier = $this->objectManager->get(Notifier::class);
 
         $notifier->sendNewDocumentNotification($newDocument);
 
@@ -238,7 +245,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
 
         if (array_key_exists('savecontinue', $requestArguments)) {
 
-            $tmpDocument = $this->objectManager->get('\EWW\Dpf\Domain\Model\Document');
+            $tmpDocument = $this->objectManager->get(Document::class);
 
             $tmpDocument->setTitle($newDocument->getTitle());
             $tmpDocument->setAuthors($newDocument->getAuthors());
@@ -260,7 +267,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
         if (array_key_exists('document', $requestArguments)) {
             $documentUid  = $this->request->getArgument('document');
             $document     = $this->documentRepository->findByUid($documentUid);
-            $mapper       = $this->objectManager->get('EWW\Dpf\Helper\DocumentMapper');
+            $mapper       = $this->objectManager->get(DocumentMapper::class);
             $documentForm = $mapper->getDocumentForm($document);
         } elseif (array_key_exists('documentForm', $requestArguments)) {
             $documentForm = $this->request->getArgument('documentForm');
@@ -289,7 +296,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
         if ($this->request->hasArgument('documentData')) {
             $documentData = $this->request->getArgument('documentData');
 
-            $formDataReader = $this->objectManager->get('EWW\Dpf\Helper\FormDataReader');
+            $formDataReader = $this->objectManager->get(FormDataReader::class);
             $formDataReader->setFormData($documentData);
             $docForm = $formDataReader->getDocumentForm();
 
@@ -321,7 +328,7 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
 
         $requestArguments = $this->request->getArguments();
 
-        $documentMapper = $this->objectManager->get('EWW\Dpf\Helper\DocumentMapper');
+        $documentMapper = $this->objectManager->get(DocumentMapper::class);
         $updateDocument = $documentMapper->getDocument($documentForm);
 
         $objectIdentifier = $updateDocument->getObjectIdentifier();
@@ -348,10 +355,10 @@ abstract class AbstractDocumentFormController extends \TYPO3\CMS\Extbase\Mvc\Con
         }
 
         // add document to local es index
-        $elasticsearchMapper = $this->objectManager->get('EWW\Dpf\Helper\ElasticsearchMapper');
+        $elasticsearchMapper = $this->objectManager->get(ElasticsearchMapper::class);
         $json                = $elasticsearchMapper->getElasticsearchJson($updateDocument);
 
-        $elasticsearchRepository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\ElasticsearchRepository');
+        $elasticsearchRepository = $this->objectManager->get(ElasticsearchRepository::class);
         // send document to index
         $elasticsearchRepository->add($updateDocument, $json);
 

--- a/Classes/Controller/AbstractSearchController.php
+++ b/Classes/Controller/AbstractSearchController.php
@@ -15,6 +15,7 @@ namespace EWW\Dpf\Controller;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use EWW\Dpf\Services\ElasticSearch;
 
 abstract class AbstractSearchController extends \EWW\Dpf\Controller\AbstractController
 {
@@ -32,7 +33,7 @@ abstract class AbstractSearchController extends \EWW\Dpf\Controller\AbstractCont
     public function getResultList($query, $type)
     {
 
-        $elasticSearch = new \EWW\Dpf\Services\ElasticSearch();
+        $elasticSearch = $this->objectManager->get(ElasticSearch::class);
         $results = $elasticSearch->search($query, $type);
 
         return $results;

--- a/Classes/Controller/AjaxDocumentFormController.php
+++ b/Classes/Controller/AjaxDocumentFormController.php
@@ -14,6 +14,10 @@ namespace EWW\Dpf\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EWW\Dpf\Services\Identifier\Urn;
+use EWW\Dpf\Services\Transfer\DocumentTransferManager;
+use EWW\Dpf\Services\Transfer\FedoraRepository;
+
 /**
  * DocumentFormController
  */
@@ -154,13 +158,13 @@ class AjaxDocumentFormController extends \EWW\Dpf\Controller\AbstractController
     public function fillOutAction($qucosaId)
     {
 
-        $urnService = $this->objectManager->get('EWW\\Dpf\\Services\\Identifier\\Urn');
+        $urnService = $this->objectManager->get(Urn::class);
 
         if (!empty($qucosaId)) {
             $urn = $urnService->getUrn($qucosaId);
         } else {
-            $documentTransferManager = $this->objectManager->get('\EWW\Dpf\Services\Transfer\DocumentTransferManager');
-            $remoteRepository        = $this->objectManager->get('\EWW\Dpf\Services\Transfer\FedoraRepository');
+            $documentTransferManager = $this->objectManager->get(DocumentTransferManager::class);
+            $remoteRepository        = $this->objectManager->get(FedoraRepository::class);
             $documentTransferManager->setRemoteRepository($remoteRepository);
 
             $qucosaId = $documentTransferManager->getNextDocumentId();

--- a/Classes/Controller/ClientController.php
+++ b/Classes/Controller/ClientController.php
@@ -14,6 +14,10 @@ namespace EWW\Dpf\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Extbase\Configuration\BackendConfigurationManager;
+use EWW\Dpf\Configuration\InputOption\Iso6392b;
+use EWW\Dpf\\Helper\InputOption\Translator;
+use EWW\Dpf\Domain\Model\InputOptionList;
 /**
  * ClientController
  */
@@ -68,7 +72,7 @@ class ClientController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
 
         $this->pageInfo = \TYPO3\CMS\Backend\Utility\BackendUtility::readPageAccess($this->selectedPageUid, $GLOBALS['BE_USER']->getPagePermsClause(1));
 
-        $configManager = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\BackendConfigurationManager');
+        $configManager = $this->objectManager->get(BackendConfigurationManager::class);
 
         $this->settings = $configManager->getConfiguration(
             $this->request->getControllerExtensionName(),
@@ -198,13 +202,13 @@ class ClientController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
     protected function addBaseInputOptionLists($storagePid)
     {
 
-        $iso6392b = $this->objectManager->get('EWW\\Dpf\\Configuration\\InputOption\\Iso6392b');
+        $iso6392b = $this->objectManager->get(Iso6392b::class);
 
-        $inputOptionTranslator = $this->objectManager->get('EWW\\Dpf\\Helper\\InputOption\\Translator');
+        $inputOptionTranslator = $this->objectManager->get(Translator::class);
         $inputOptionTranslator->init(get_class($iso6392b));
 
         // create input option list for the default language
-        $languageOptionList = $this->objectManager->get('EWW\\Dpf\\Domain\\Model\\InputOptionList');
+        $languageOptionList = $this->objectManager->get(InputOptionList::class);
         $languageOptionList->setName('languageList');
         $languageOptionList->setPid($storagePid);
         $languageOptionList->setSysLanguageUid(0);
@@ -236,7 +240,7 @@ class ClientController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                         $valueLabelList = $inputOptionTranslator->translate($iso6392b->getValues(), $langIsoCode);
                         $displayName    = $inputOptionTranslator->translate(array('languageList'), $langIsoCode);
 
-                        $translatedOptionList = $this->objectManager->get('EWW\\Dpf\\Domain\\Model\\InputOptionList');
+                        $translatedOptionList = $this->objectManager->get(InputOptionList::class);
                         $translatedOptionList->setDisplayName(implode('', $displayName));
                         $translatedOptionList->setPid($storagePid);
                         $translatedOptionList->setSysLanguageUid($installedLanguage->getUid());

--- a/Classes/Controller/DocumentFormBEController.php
+++ b/Classes/Controller/DocumentFormBEController.php
@@ -14,6 +14,8 @@ namespace EWW\Dpf\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EWW\Dpf\Services\Transfer\ElasticsearchRepository;
+
 class DocumentFormBEController extends AbstractDocumentFormController
 {
 
@@ -43,7 +45,7 @@ class DocumentFormBEController extends AbstractDocumentFormController
 
         $document = $this->documentRepository->findByUid($documentData['documentUid']);
 
-        $elasticsearchRepository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\ElasticsearchRepository');
+        $elasticsearchRepository = $this->objectManager->get(ElasticsearchRepository::class);
         // send document to index
         $elasticsearchRepository->delete($document, "");
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -14,6 +14,13 @@ namespace EWW\Dpf\Controller;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EWW\Dpf\Domain\Model\Document;
+use EWW\Dpf\Services\Transfer\DocumentTransferManager;
+use EWW\Dpf\Services\Transfer\FedoraRepository;
+use EWW\Dpf\Services\Transfer\ElasticsearchRepository;
+use EWW\Dpf\Services\ElasticSearch;
+use EWW\Dpf\Helper\ElasticsearchMapper;
+
 /**
  * SearchController
  */
@@ -188,8 +195,8 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
      */
     public function importAction($documentObjectIdentifier, $objectState)
     {
-        $documentTransferManager = $this->objectManager->get('\EWW\Dpf\Services\Transfer\DocumentTransferManager');
-        $remoteRepository        = $this->objectManager->get('\EWW\Dpf\Services\Transfer\FedoraRepository');
+        $documentTransferManager = $this->objectManager->get(DocumentTransferManager::class);
+        $remoteRepository        = $this->objectManager->get(FedoraRepository::class);
         $documentTransferManager->setRemoteRepository($remoteRepository);
 
         $args[] = $documentObjectIdentifier;
@@ -226,9 +233,9 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
     {
         $document = $this->documentRepository->findByObjectIdentifier($documentObjectIdentifier);
 
-        if (is_a($document, '\EWW\Dpf\Domain\Model\Document')) {
-            $elasticsearchRepository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\ElasticsearchRepository');
-            $elasticsearchMapper     = $this->objectManager->get('EWW\Dpf\Helper\ElasticsearchMapper');
+        if (is_a($document, Document::class)) {
+            $elasticsearchRepository = $this->objectManager->get(ElasticsearchRepository::class);
+            $elasticsearchMapper     = $this->objectManager->get(ElasticsearchMapper::class);
             $json                    = $elasticsearchMapper->getElasticsearchJson($document);
             // send document to index
             $elasticsearchRepository->add($document, $json);
@@ -245,7 +252,7 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
      */
     public function doubletCheckAction(\EWW\Dpf\Domain\Model\Document $document)
     {
-        $elasticSearch = new \EWW\Dpf\Services\ElasticSearch();
+        $elasticSearch = $this->objectManager->get(ElasticSearch::class);
 
         $client = $this->clientRepository->findAll()->current();
 

--- a/Classes/Controller/SearchController.php
+++ b/Classes/Controller/SearchController.php
@@ -57,7 +57,6 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
 
         $args          = $this->request->getArguments();
 
-        $elasticSearch = new \EWW\Dpf\Services\ElasticSearch();
         // assign result list from elastic search
         $this->view->assign('searchList', $args['results']);
         $this->view->assign('alreadyImported', $objectIdentifiers);
@@ -104,7 +103,6 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
 
         $args          = $this->request->getArguments();
 
-        $elasticSearch = new \EWW\Dpf\Services\ElasticSearch();
         // assign result list from elastic search
         $this->view->assign('searchList', $args['results']);
         $this->view->assign('alreadyImported', $objectIdentifiers);
@@ -119,8 +117,6 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
      */
     public function latestAction()
     {
-        $elasticSearch = new \EWW\Dpf\Services\ElasticSearch();
-
         $query = $this->searchLatest();
 
         // set type local vs object
@@ -140,8 +136,6 @@ class SearchController extends \EWW\Dpf\Controller\AbstractSearchController
     {
         // perform search action
         $args = $this->request->getArguments();
-
-        $elasticSearch = new \EWW\Dpf\Services\ElasticSearch();
 
         // reset session pagination
         $sessionVars                = $GLOBALS['BE_USER']->getSessionData('tx_dpf');

--- a/Classes/Domain/Repository/ProcessNumberRepository.php
+++ b/Classes/Domain/Repository/ProcessNumberRepository.php
@@ -14,6 +14,8 @@ namespace EWW\Dpf\Domain\Repository;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings;
+
 /**
  * The repository for ProcessNumbers
  */
@@ -21,7 +23,7 @@ class ProcessNumberRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 {
 
     public function initializeObject() {
-        $querySettings = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Persistence\\Generic\\Typo3QuerySettings');
+        $querySettings = $this->objectManager->get(Typo3QuerySettings::class);
         $querySettings->setRespectStoragePage(FALSE);
         $this->setDefaultQuerySettings($querySettings);
     }

--- a/Classes/Helper/DocumentMapper.php
+++ b/Classes/Helper/DocumentMapper.php
@@ -14,6 +14,10 @@ namespace EWW\Dpf\Helper;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EWW\Dpf\Services\Identifier\Urn;
+use EWW\Dpf\Domain\Model\Document;
+use EWW\Dpf\Services\ProcessNumber\ProcessNumberGenerator;
+
 class DocumentMapper
 {
 
@@ -83,7 +87,7 @@ class DocumentMapper
         }
 
         if (!empty($qucosaId)) {
-            $urnService = $this->objectManager->get('EWW\\Dpf\\Services\\Identifier\\Urn');
+            $urnService = $this->objectManager->get(Urn::class);
             $qucosaUrn  = $urnService->getUrn($qucosaId);
             $documentForm->setQucosaUrn($qucosaUrn);
         }
@@ -293,12 +297,12 @@ class DocumentMapper
         if ($documentForm->getDocumentUid()) {
             $document = $this->documentRepository->findByUid($documentForm->getDocumentUid());
         } else {
-            $document = $this->objectManager->get('\EWW\Dpf\Domain\Model\Document');
+            $document = $this->objectManager->get(Document::class);
         }
 
         $processNumber = $document->getProcessNumber();
         if (empty($processNumber)) {
-            $processNumberGenerator = $this->objectManager->get("EWW\\Dpf\\Services\\ProcessNumber\\ProcessNumberGenerator");
+            $processNumberGenerator = $this->objectManager->get(ProcessNumberGenerator::class);
             $processNumber = $processNumberGenerator->getProcessNumber();
             $document->setProcessNumber($processNumber);
         }

--- a/Classes/Helper/FormDataReader.php
+++ b/Classes/Helper/FormDataReader.php
@@ -14,6 +14,8 @@ namespace EWW\Dpf\Helper;
  * The TYPO3 project - inspiring people to share!
  */
 
+use EWW\Dpf\Domain\Model\File;
+
 class FormDataReader
 {
 
@@ -279,7 +281,7 @@ class FormDataReader
     {
 
         if (empty($file)) {
-            $file = $this->objectManager->get('EWW\Dpf\Domain\Model\File');
+            $file = $this->objectManager->get(File::class);
         }
 
         $fileName = uniqid(time(), true);

--- a/Classes/Helper/InputOption/Translator.php
+++ b/Classes/Helper/InputOption/Translator.php
@@ -14,6 +14,8 @@ namespace EWW\Dpf\Helper\InputOption;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
+
 class Translator
 {
 
@@ -87,7 +89,7 @@ class Translator
      */
     public function getDefaultLanguage()
     {
-        $configurationManager = $this->objectManager->get('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager');
+        $configurationManager = $this->objectManager->get(ConfigurationManager::class);
         $extbaseConfiguration = $configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
 
         $defaultLanguage = $extbaseConfiguration['config.']['language'];

--- a/Classes/Helper/UploadFileUrl.php
+++ b/Classes/Helper/UploadFileUrl.php
@@ -14,7 +14,8 @@ namespace EWW\Dpf\Helper;
  * The TYPO3 project - inspiring people to share!
  */
 
-
+use EWW\Dpf\Configuration\ClientConfigurationManager;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
 
 class UploadFileUrl
 {
@@ -27,8 +28,8 @@ class UploadFileUrl
     protected $clientConfigurationManager;
 
     public function __construct() {
-        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $this->clientConfigurationManager = $objectManager->get('EWW\\Dpf\\Configuration\\ClientConfigurationManager');
+        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $this->clientConfigurationManager = $objectManager->get(ClientConfigurationManager::class);
     }
 
 

--- a/Classes/Plugins/MetaTags/MetaTags.php
+++ b/Classes/Plugins/MetaTags/MetaTags.php
@@ -15,6 +15,7 @@ namespace EWW\Dpf\Plugins\MetaTags;
  */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 /**
  * Plugin 'DPF: MetaTags' for the 'dlf / dpf' extension.
@@ -175,7 +176,7 @@ class MetaTags extends \tx_dlf_plugin
 
                     // we need to make instance of cObj here because its not available in this context
                     /** @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj */
-                    $cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
+                    $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
 
                     // replace uid with URI to dpf API
                     $outArray['citation_pdf_url'][] = $cObj->typoLink_URL($conf);

--- a/Classes/Services/ElasticSearch.php
+++ b/Classes/Services/ElasticSearch.php
@@ -15,6 +15,8 @@ namespace EWW\Dpf\Services;
  */
 
 use \Elasticsearch\Client as Client;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use EWW\Dpf\Configuration\ClientConfigurationManager;
 
 /**
  * ElasticSearch
@@ -40,8 +42,8 @@ class ElasticSearch
      */
     public function __construct()
     {
-        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $clientConfigurationManager = $objectManager->get('EWW\\Dpf\\Configuration\\ClientConfigurationManager');
+        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $clientConfigurationManager = $objectManager->get(ClientConfigurationManager::class);
 
         $this->server = $clientConfigurationManager->getElasticSearchHost();
         $this->port   = $clientConfigurationManager->getElasticSearchPort();

--- a/Classes/Services/Logger/TransferLogger.php
+++ b/Classes/Services/Logger/TransferLogger.php
@@ -13,7 +13,10 @@ namespace EWW\Dpf\Services\Logger;
  *
  * The TYPO3 project - inspiring people to share!
  */
- 
+
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use EWW\Dpf\Domain\Repository\DocumentTransferLogRepository;
+use EWW\Dpf\Domain\Model\DocumentTransferLog;
 
 class TransferLogger
 {
@@ -27,10 +30,10 @@ class TransferLogger
     public static function log($action, $documentUid, $objectIdentifier, $response)
     {
 
-        $objectManager                 = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $documentTransferLogRepository = $objectManager->get('\\EWW\\Dpf\\Domain\\Repository\\DocumentTransferLogRepository');
+        $objectManager                 = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $documentTransferLogRepository = $objectManager->get(DocumentTransferLogRepository::class);
 
-        $documentTransferLog = $objectManager->get('\\EWW\\Dpf\\Domain\\Model\\DocumentTransferLog');
+        $documentTransferLog = $objectManager->get(DocumentTransferLog::class);
         $documentTransferLog->setResponse(print_r($response, true));
         $documentTransferLog->setAction($action);
         $documentTransferLog->setDocumentUid($documentUid);

--- a/Classes/Services/ProcessNumber/ProcessNumberGenerator.php
+++ b/Classes/Services/ProcessNumber/ProcessNumberGenerator.php
@@ -14,17 +14,23 @@ namespace EWW\Dpf\Services\ProcessNumber;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Extbase\Persistence\PersistenceManagerInterface;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use EWW\Dpf\Domain\Repository\ProcessNumberRepository;
+use EWW\Dpf\Domain\Model\ProcessNumber;
+use EWW\Dpf\Domain\Repository\ClientRepository;
+
 class ProcessNumberGenerator
 {
     public function getProcessNumber($ownerId = NULL) {
-        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $processNumberRepository = $objectManager->get("EWW\\Dpf\\Domain\\Repository\\ProcessNumberRepository");
-        $persistenceManager = $objectManager->get("TYPO3\\CMS\\Extbase\\Persistence\\PersistenceManagerInterface");
+        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $processNumberRepository = $objectManager->get(ProcessNumberRepository::class);
+        $persistenceManager = $objectManager->get(PersistenceManagerInterface::class);
 
         $processNumberRepository->startTransaction();
         try {
             if (!$ownerId) {
-                $clientRepository = $objectManager->get("EWW\\Dpf\\Domain\\Repository\\ClientRepository");
+                $clientRepository = $objectManager->get(ClientRepository::class);
                 $ownerId = $clientRepository->findAll()->getFirst()->getOwnerId();
             }
 
@@ -38,7 +44,7 @@ class ProcessNumberGenerator
                 $processNumber->setCounter($counter);
                 $processNumberRepository->update($processNumber);
             } else {
-                $processNumber = $objectManager->get("EWW\\Dpf\\Domain\\Model\\ProcessNumber");
+                $processNumber = $objectManager->get(ProcessNumber::class);
                 $processNumber->setOwnerId(strtolower($ownerId));
                 $processNumber->setYear($currentYear);
                 $processNumber->setCounter(1);

--- a/Classes/Services/Transfer/DocumentTransferManager.php
+++ b/Classes/Services/Transfer/DocumentTransferManager.php
@@ -14,7 +14,9 @@ namespace EWW\Dpf\Services\Transfer;
  * The TYPO3 project - inspiring people to share!
  */
 
-use \EWW\Dpf\Domain\Model\Document;
+use EWW\Dpf\Domain\Model\Document;
+use EWW\Dpf\Services\Transfer\ElasticsearchRepository;
+use EWW\Dpf\Domain\Model\File;
 
 class DocumentTransferManager
 {
@@ -123,7 +125,7 @@ class DocumentTransferManager
             $this->documentRepository->remove($document);
 
             // remove document from local index
-            $elasticsearchRepository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\ElasticsearchRepository');
+            $elasticsearchRepository = $this->objectManager->get(ElasticsearchRepository::class);
             $elasticsearchRepository->delete($document, "");
 
             return true;
@@ -176,7 +178,7 @@ class DocumentTransferManager
             $this->documentRepository->remove($document);
 
             // remove document from local index
-            $elasticsearchRepository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\ElasticsearchRepository');
+            $elasticsearchRepository = $this->objectManager->get(ElasticsearchRepository::class);
             $elasticsearchRepository->delete($document, "");
 
             return true;
@@ -236,7 +238,7 @@ class DocumentTransferManager
                     break;
             }
 
-            $document = $this->objectManager->get('\EWW\Dpf\Domain\Model\Document');
+            $document = $this->objectManager->get(Document::class);
             $document->setObjectIdentifier($remoteId);
             $document->setState($objectState);
             $document->setTitle($title);
@@ -255,7 +257,7 @@ class DocumentTransferManager
 
             foreach ($mets->getFiles() as $attachment) {
 
-                $file = $this->objectManager->get('\EWW\Dpf\Domain\Model\File');
+                $file = $this->objectManager->get(File::class);
                 $file->setContentType($attachment['mimetype']);
                 $file->setDatastreamIdentifier($attachment['id']);
                 $file->setLink($attachment['href']);
@@ -312,7 +314,7 @@ class DocumentTransferManager
                     $this->documentRepository->update($document);
                     $this->documentRepository->remove($document);
                     // remove document from local index
-                    $elasticsearchRepository = $this->objectManager->get('\EWW\Dpf\Services\Transfer\ElasticsearchRepository');
+                    $elasticsearchRepository = $this->objectManager->get(ElasticsearchRepository::class);
                     $elasticsearchRepository->delete($document, $state);
                     break;
             }

--- a/Classes/Services/Transfer/ElasticsearchRepository.php
+++ b/Classes/Services/Transfer/ElasticsearchRepository.php
@@ -20,6 +20,8 @@ require_once $extpath . '/Lib/Vendor/Httpful/Bootstrap.php';
 \Httpful\Bootstrap::init();
 
 use \Httpful\Request;
+use TYPO3\CMS\Extbase\Object\ObjectManager;
+use EWW\Dpf\Configuration\ClientConfigurationManager;
 
 class ElasticsearchRepository implements Repository
 {
@@ -42,10 +44,10 @@ class ElasticsearchRepository implements Repository
 
     public function __construct()
     {
-        
-        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $clientConfigurationManager = $objectManager->get('EWW\\Dpf\\Configuration\\ClientConfigurationManager');
-    
+
+        $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(ObjectManager::class);
+        $clientConfigurationManager = $objectManager->get(ClientConfigurationManager::class);
+
         $this->host = $clientConfigurationManager->getElasticSearchHost() . ':' . $clientConfigurationManager->getElasticSearchPort();
 
         $this->index = 'fedora';

--- a/Classes/ViewHelpers/Link/DataCiteViewHelper.php
+++ b/Classes/ViewHelpers/Link/DataCiteViewHelper.php
@@ -17,6 +17,7 @@ namespace EWW\Dpf\ViewHelpers\Link;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class DataCiteViewHelper extends AbstractBackendViewHelper
 {
@@ -49,7 +50,7 @@ class DataCiteViewHelper extends AbstractBackendViewHelper
         );
 
         /** @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj */
-        $cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
 
         // replace uid with URI to dpf API
         $dataCite = $cObj->typoLink_URL($conf);

--- a/Classes/ViewHelpers/Link/PreviewViewHelper.php
+++ b/Classes/ViewHelpers/Link/PreviewViewHelper.php
@@ -17,6 +17,8 @@ namespace EWW\Dpf\ViewHelpers\Link;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
+use TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController;
+use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
 
 class PreviewViewHelper extends AbstractBackendViewHelper
 {
@@ -49,7 +51,7 @@ class PreviewViewHelper extends AbstractBackendViewHelper
             $GLOBALS['TT'] = new \TYPO3\CMS\Core\TimeTracker\NullTimeTracker;
             $GLOBALS['TT']->start();
         }
-        $GLOBALS['TSFE'] = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\Controller\\TypoScriptFrontendController', $GLOBALS['TYPO3_CONF_VARS'], $id, $typeNum);
+        $GLOBALS['TSFE'] = GeneralUtility::makeInstance(TypoScriptFrontendController::class, $GLOBALS['TYPO3_CONF_VARS'], $id, $typeNum);
         $GLOBALS['TSFE']->connectToDB();
         $GLOBALS['TSFE']->initFEuser();
         $GLOBALS['TSFE']->determineId();
@@ -87,7 +89,7 @@ class PreviewViewHelper extends AbstractBackendViewHelper
         // we need to make instance of cObj here because its not available in this context
         $this->initTSFE($apiPid, 0);
         /** @var \TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $cObj */
-        $cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
+        $cObj = GeneralUtility::makeInstance(ContentObjectRenderer::class);
 
         // replace uid with URI to dpf API
         $previewMets = $cObj->typoLink_URL($conf);

--- a/class.ext_update.php
+++ b/class.ext_update.php
@@ -16,6 +16,10 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
+use EWW\Dpf\Domain\Repository\ClientRepository;
+use EWW\Dpf\Services\ProcessNumber\ProcessNumberGenerator;
+use EWW\Dpf\Domain\Repository\DocumentRepository;
+
 class ext_update {
 
     public function access() {
@@ -24,11 +28,11 @@ class ext_update {
 
     public function main() {
         $objectManager = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\Object\\ObjectManager');
-        $clientRepository = $objectManager->get("EWW\\Dpf\\Domain\\Repository\\ClientRepository");
+        $clientRepository = $objectManager->get(ClientRepository);
 
-        $processNumberGenerator = $objectManager->get("EWW\\Dpf\\Services\\ProcessNumber\\ProcessNumberGenerator");
+        $processNumberGenerator = $objectManager->get(ProcessNumberGenerator::class);
 
-        $documentRepository = $objectManager->get("EWW\\Dpf\\Domain\\Repository\\DocumentRepository");
+        $documentRepository = $objectManager->get(DocumentRepository::class);
 
         $documents = $documentRepository->findDocumentsWithoutProcessNumber();
 


### PR DESCRIPTION
This is the way, the TYPO3 core is coding now:
- put the used classes in "use" above the class name
- use "::class" notation and no strings anymore