### PR TITLE
Disable submit button after click to avoid multiple form submits

### DIFF
--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -101,6 +101,11 @@ var validateFormAndSave = function() {
     jQuery("#validDocument").val("0");
     if (validateForm()) {
         jQuery("#validDocument").val("1");
+
+        jQuery("#new-document-form #save").prop("disabled", true);
+
+        jQuery('#new-document-form').submit();
+
         return true;
     }
     return false;


### PR DESCRIPTION
In some browsers (e.g. IE 11) it is possible to press the submit button multiple times. This submits the form multiple times and for each submit, a new document is created.

This simple patch, disables the submit button on first click and submits the form by javascript.