### PR TITLE
Permit dataCite API action to all hosts

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -56,18 +56,21 @@ plugin.tx_dpf {
         }
 }
 
-# Actions, only allowed for developers and localhost
+# Actions, only allowed for developers and configured hosts
 [IP=devIP][hostname={$plugin.tx_dpf.settings.api.allowedHosts}]
 	plugin.tx_dpf.settings.allowedActions {
 		1 = mets
 		2 = preview
-		3 = dataCite
+		
 	}
 [end]
 
-# Action which is always allowed
-plugin.tx_dpf.settings.allowedActions.4 = attachment
-plugin.tx_dpf.settings.allowedActions.5 = zip
+# Actions which are always allowed
+plugin.tx_dpf.settings.allowedActions {
+	3 = dataCite
+	4 = attachment
+	5 = zip
+}
 
 plugin.tx_dpf._CSS_DEFAULT_STYLE (
 	textarea.f3-form-error {


### PR DESCRIPTION
The `dataCite` API action gets called from TYPO3 backend but the link URL is resolved by the browser and not the TYPO3 system itself.