### PR TITLE
Fix format of documents tstamp field in list view.

### DIFF
--- a/Configuration/TCA/tx_dpf_domain_model_document.php
+++ b/Configuration/TCA/tx_dpf_domain_model_document.php
@@ -201,7 +201,7 @@ return array(
             'exclude' => 0,
             'label'   => 'Timestamp',
             'config'  => array(
-                'type'   => 'none',
+                'type'   => 'input',
                 'format' => 'datetime',
                 'eval'   => 'datetime',
             ),


### PR DESCRIPTION
Using the TYPO3 default backend list module to view the database records,
the tstamp field of table tx_dpf_domain_model_document shown as UNIX
timestamp.

This is due to overwriting the tstamp column in TCA. With type=none, no
formatting is done by BackendUtility::getProcessedValue. The type has to
be input. Even though no (user) input will be done here.