### PR TITLE
Cmr 136

### DIFF
--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -184,13 +184,18 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
 
         // stop here, if inactive Fedora objects are not allowed to be disseminated
 
-        $restrictToActiveDocuments = TRUE;
+        // allow dissemination if a request parameter 'deliverInactive' has the secret
+        // TYPOScript configuration value 'deliverInactiveSecretKey'
 
-        if ('yes' == $piVars['deliverInactive']) {
+        $restrictToActiveDocuments = TRUE;
+        $deliverInactiveSecretKey = $this->settings['deliverInactiveSecretKey'];
+
+        if ($deliverInactiveSecretKey == $piVars['deliverInactive']) {
             $restrictToActiveDocuments = FALSE;
         }
 
         if (TRUE === $restrictToActiveDocuments) {
+            // if restriction applies, check object state before dissemination
             $objectProfileURI = rtrim('http://' . $fedoraHost,"/").'/fedora/objects/'.$piVars['qid'].'?format=XML';
             $objectProfileXML = file_get_contents($objectProfileURI);
             if (FALSE !== $objectProfileXML) {

--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -182,20 +182,29 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
                 return 'No such action';
         }
 
-        // stop here, if Fedora document is not active
-        $objectProfileURI = rtrim('http://' . $fedoraHost,"/").'/fedora/objects/'.$piVars['qid'].'?format=XML';
-        $objectProfileXML = file_get_contents($objectProfileURI);
-        if (FALSE !== $objectProfileXML) {
-            $objectProfileDOM = new \DOMDocument('1.0', 'UTF-8');
-            if (TRUE === $objectProfileDOM->loadXML($objectProfileXML)) {
-                $objectState = $objectProfileDOM->getElementsByTagName('objState')[0];
-                if ('I' === $objectState->nodeValue) {
-                    $this->response->setStatus(403);
-                    return 'Forbidden';
-                }
-                if ('D' === $objectState->nodeValue) {
-                    $this->response->setStatus(404);
-                    return 'Not Found';
+        // stop here, if inactive Fedora objects are not allowed to be disseminated
+
+        $restrictToActiveDocuments = TRUE;
+
+        if ('yes' == $piVars['deliverInactive']) {
+            $restrictToActiveDocuments = FALSE;
+        }
+
+        if (TRUE === $restrictToActiveDocuments) {
+            $objectProfileURI = rtrim('http://' . $fedoraHost,"/").'/fedora/objects/'.$piVars['qid'].'?format=XML';
+            $objectProfileXML = file_get_contents($objectProfileURI);
+            if (FALSE !== $objectProfileXML) {
+                $objectProfileDOM = new \DOMDocument('1.0', 'UTF-8');
+                if (TRUE === $objectProfileDOM->loadXML($objectProfileXML)) {
+                    $objectState = $objectProfileDOM->getElementsByTagName('objState')[0];
+                    if ('I' === $objectState->nodeValue) {
+                        $this->response->setStatus(403);
+                        return 'Forbidden';
+                    }
+                    if ('D' === $objectState->nodeValue) {
+                        $this->response->setStatus(404);
+                        return 'Not Found';
+                    }
                 }
             }
         }

--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -189,9 +189,13 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
             $objectProfileDOM = new \DOMDocument('1.0', 'UTF-8');
             if (TRUE === $objectProfileDOM->loadXML($objectProfileXML)) {
                 $objectState = $objectProfileDOM->getElementsByTagName('objState')[0];
-                if ('A' !== $objectState->nodeValue) {
+                if ('I' === $objectState->nodeValue) {
                     $this->response->setStatus(403);
                     return 'Forbidden';
+                }
+                if ('D' === $objectState->nodeValue) {
+                    $this->response->setStatus(404);
+                    return 'Not Found';
                 }
             }
         }

--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -206,6 +206,9 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
                         return 'Not Found';
                     }
                 }
+            } else {
+                $this->response->setStatus(500);
+                return 'Internal Server Error';
             }
         }
 

--- a/Classes/Controller/GetFileController.php
+++ b/Classes/Controller/GetFileController.php
@@ -182,6 +182,20 @@ class GetFileController extends \EWW\Dpf\Controller\AbstractController
                 return 'No such action';
         }
 
+        // stop here, if Fedora document is not active
+        $objectProfileURI = rtrim('http://' . $fedoraHost,"/").'/fedora/objects/'.$piVars['qid'].'?format=XML';
+        $objectProfileXML = file_get_contents($objectProfileURI);
+        if (FALSE !== $objectProfileXML) {
+            $objectProfileDOM = new \DOMDocument('1.0', 'UTF-8');
+            if (TRUE === $objectProfileDOM->loadXML($objectProfileXML)) {
+                $objectState = $objectProfileDOM->getElementsByTagName('objState')[0];
+                if ('A' !== $objectState->nodeValue) {
+                    $this->response->setStatus(403);
+                    return 'Forbidden';
+                }
+            }
+        }
+
         // get remote header and set it before passtrough
         $headers = get_headers($path);
 

--- a/Classes/ViewHelpers/FileUrlViewHelper.php
+++ b/Classes/ViewHelpers/FileUrlViewHelper.php
@@ -14,8 +14,30 @@ namespace EWW\Dpf\ViewHelpers;
  * The TYPO3 project - inspiring people to share!
  */
 
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface;
+
 class FileUrlViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper
 {
+    /**
+     * Secret API key for delivering inactive documents.
+     * @var string
+     */
+    private $secretKey;
+
+    /**
+     * Initialize secret key from plugin TYPOScript configuration.
+     */
+    public function initialize() {
+        parent::initialize();
+
+        $configurationManager = GeneralUtility::makeInstance('TYPO3\\CMS\\Extbase\\Configuration\\ConfigurationManager');
+        $settings = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+
+        if (isset($settings['plugin.']['tx_dpf.']['settings.']['deliverInactiveSecretKey'])) {
+            $this->secretKey = $settings['plugin.']['tx_dpf.']['settings.']['deliverInactiveSecretKey'];
+        }
+    }
 
     /**
      *
@@ -24,9 +46,19 @@ class FileUrlViewHelper extends \TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHel
      */
     public function render($uri)
     {
-        return $this->buildFileUri($uri);
+        $fileUri = $this->buildFileUri($uri);
+
+        // pass configured API secret key parameter to enable dissemination for inactive documents
+        if (isset($this->secretKey)) {
+            $fileUri .= '?tx_dpf[deliverInactive]=' . $this->secretKey;
+        }
+
+        return $fileUri;
     }
 
+    /**
+     * Construct file URI
+     */
     protected function buildFileUri($uri)
     {
 

--- a/Classes/ViewHelpers/Link/PreviewViewHelper.php
+++ b/Classes/ViewHelpers/Link/PreviewViewHelper.php
@@ -57,7 +57,14 @@ class PreviewViewHelper extends AbstractBackendViewHelper
     protected function getViewIcon(array $row, $pageUid, $apiPid, $insideText, $class)
     {
 
-        $previewMets = BackendUtility::getViewDomain($pageUid) . '/index.php?id='.$apiPid.'&tx_dpf[qid]=' . $row['uid'] . '&tx_dpf[action]=' . $row['action'];
+        $previewMets = BackendUtility::getViewDomain($pageUid)
+            . '/index.php?id=' . $apiPid
+            . '&tx_dpf[qid]=' . $row['uid']
+            . '&tx_dpf[action]=' . $row['action'];
+
+        if (array_key_exists('deliverInactive', $row)) {
+            $previewMets .= '&tx_dpf[deliverInactive]=' . $row['deliverInactive'];
+        }
 
         $additionalGetVars = '&tx_dlf[id]=' . urlencode($previewMets) . '&no_cache=1';
         $title = \TYPO3\CMS\Extbase\Utility\LocalizationUtility::translate('manager.tooltip.preview', 'dpf', $arguments = null);
@@ -115,6 +122,8 @@ class PreviewViewHelper extends AbstractBackendViewHelper
             $row['action'] = 'mets';
 
             $row['uid'] = $arguments['documentObjectIdentifier'];
+
+            $row['deliverInactive'] = 'yes';
 
         }
 

--- a/Classes/ViewHelpers/Link/PreviewViewHelper.php
+++ b/Classes/ViewHelpers/Link/PreviewViewHelper.php
@@ -123,7 +123,12 @@ class PreviewViewHelper extends AbstractBackendViewHelper
 
             $row['uid'] = $arguments['documentObjectIdentifier'];
 
-            $row['deliverInactive'] = 'yes';
+            // pass configured API secret key parameter to enable dissemination of inactive documents
+            $settings = $configurationManager->getConfiguration(ConfigurationManagerInterface::CONFIGURATION_TYPE_SETTINGS);
+
+            if (array_key_exists('plugin.tx_dpf.settings.deliverInactiveSecretKey', $settings)) {
+                $row['deliverInactive'] = $this->settings['plugin.tx_dpf.settings.deliverInactiveSecretKey'];
+            }
 
         }
 

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -90,6 +90,9 @@ plugin.tx_dpf.settings.allowedActions {
 	5 = zip
 }
 
+# !!ChangeThis!! Secret key for delivering inactive documents via API
+plugin.tx_dpf.settings.deliverInactiveSecretKey = 6fc4d012-11ac-46bf-9bfc-82240628656b
+
 plugin.tx_dpf._CSS_DEFAULT_STYLE (
 	textarea.f3-form-error {
 		background-color:#FF9F9F;


### PR DESCRIPTION
Block access to dissemination for Fedora objects which are not in state `active`, unless `deliverInactive` parameter is given.

Resolves https://jira.slub-dresden.de/browse/CMR-136