### PR TITLE
Fix issue with overlay in new document form

### DIFF
--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -72,6 +72,9 @@
     border: 0 none;
 }
 
+#content form .tab-content {
+    padding-top: 1px;
+}
 
 /* -- basic setup ------------------------------------------------------------------------ */
 


### PR DESCRIPTION
This PR fixes an overlay issue on the new document form. Please test the changes for possible side-effects. The CSS selector should be specific enough though. It looks good on Safari and Firefox for me but I only made the changes via the in-browser developer tools.

**Before:**
![before](https://user-images.githubusercontent.com/180686/52347666-d1e1c680-2a22-11e9-94d8-d82d9538df6e.png)

**After:**
![after](https://user-images.githubusercontent.com/180686/52347685-dc03c500-2a22-11e9-80cc-12b9a7e2b8ef.png)
