### PR TITLE
Add submit on enter when datepicker is active

### DIFF
--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -468,6 +468,10 @@ var datepicker = function() {
         format: 'DD.MM.YYYY',
         locale: language,
         keepInvalid: true
+    }).on("keydown", function(e){
+        if (e.which == 13) {
+            $('.datetimepicker').closest('form').submit();
+        }
     });
 }
 var isDate = function(value) {


### PR DESCRIPTION
This PR adds a jQuery EventListener on datepickers to enable form submission when `Enter` is pressed. By triggering the event the closest form is found and submitted.

I have only tested this with in-browser developer tools so far.