### PR TITLE
Fix gnd search

### DIFF
--- a/Classes/Controller/GndController.php
+++ b/Classes/Controller/GndController.php
@@ -47,13 +47,8 @@ class GndController extends \EWW\Dpf\Controller\AbstractController
             $i++;
         }
 
-        if (empty($listArray)) {
-            echo json_encode(null);
-        } else {
-            echo json_encode($listArray);
-        }
-
-        return '';
+        $this->request->setFormat('json');
+        $this->view->assign('results', $listArray);
     }
 
 }

--- a/Classes/ViewHelpers/Format/JsonViewHelper.php
+++ b/Classes/ViewHelpers/Format/JsonViewHelper.php
@@ -1,0 +1,75 @@
+<?php
+namespace EWW\Dpf\ViewHelpers\Format;
+
+// backport of TYPO3 8.7!
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It originated from the Neos.Form package (www.neos.io)
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+
+/**
+ * Wrapper for PHPs json_encode function.
+ *
+ * = Examples =
+ *
+ * <code title="encoding a view variable">
+ * {someArray -> f:format.json()}
+ * </code>
+ * <output>
+ * ["array","values"]
+ * // depending on the value of {someArray}
+ * </output>
+ *
+ * <code title="associative array">
+ * {f:format.json(value: {foo: 'bar', bar: 'baz'})}
+ * </code>
+ * <output>
+ * {"foo":"bar","bar":"baz"}
+ * </output>
+ *
+ * <code title="non-associative array with forced object">
+ * {f:format.json(value: {0: 'bar', 1: 'baz'}, forceObject: true)}
+ * </code>
+ * <output>
+ * {"0":"bar","1":"baz"}
+ * </output>
+ *
+ */
+class JsonViewHelper extends AbstractViewHelper
+{
+    /**
+     * Applies json_encode() on the specified value.
+     *
+     * Outputs content with its JSON representation. To prevent issues in HTML context, occurrences
+     * of greater-than or less-than characters are converted to their hexadecimal representations.
+     *
+     * If $forceObject is TRUE a JSON object is outputted even if the value is a non-associative array
+     * Example: array('foo', 'bar') as input will not be ["foo","bar"] but {"0":"foo","1":"bar"}
+     *
+     * @param array $value
+     * @param boolean $forceObject
+     * @see http://www.php.net/manual/en/function.json-encode.php
+     * @return string
+     */
+    public static function render(array $value, $forceObject = false)
+    {
+        $options = JSON_HEX_TAG;
+        if ($forceObject !== false) {
+            $options = $options | JSON_FORCE_OBJECT;
+        }
+        return json_encode($value, $options);
+    }
+}

--- a/Resources/Private/Templates/Gnd/Search.html
+++ b/Resources/Private/Templates/Gnd/Search.html
@@ -1,0 +1,16 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+{namespace dpf = EWW\Dpf\ViewHelpers}
+<dpf:format.json value="{results}" />

--- a/Resources/Private/Templates/Gnd/Search.json
+++ b/Resources/Private/Templates/Gnd/Search.json
@@ -1,2 +1,0 @@
-{namespace dpf = EWW\Dpf\ViewHelpers}
-<dpf:format.json value="{results}" />

--- a/Resources/Private/Templates/Gnd/Search.json
+++ b/Resources/Private/Templates/Gnd/Search.json
@@ -1,0 +1,2 @@
+{namespace dpf = EWW\Dpf\ViewHelpers}
+<dpf:format.json value="{results}" />


### PR DESCRIPTION
This should fix the gnd search feature in production environment. 
The action delivers the array as usual to the view. The view transforms the array to json and delivers to the client.
Unfortunately the json viewhelper is not part of TYPO3 7.6 yet. It comes with 8.7 why we need a backport.