### PR TITLE
Fix for TYPO3 8: Missing comma when calling the inArray Viewhelper.

### DIFF
--- a/Resources/Private/Partials/Search/ResultList.html
+++ b/Resources/Private/Partials/Search/ResultList.html
@@ -39,7 +39,7 @@
     </thead>
     <tbody>
     <f:for each="{searchList.hits}" as="entry">
-        <f:if condition="{dpf:inArray(needle:'{entry._source.PID}' array:'{alreadyImported}')}">
+        <f:if condition="{dpf:inArray(needle:'{entry._source.PID}', array:'{alreadyImported}')}">
             <f:then>
                 <tr class="success">
             </f:then>
@@ -86,7 +86,7 @@
                         <span class="glyphicon glyphicon-info-sign"></span>
                     </dpf:link.dataCite>
 
-                    <f:if condition="{dpf:inArray(needle:'{entry._id}' array:'{alreadyImported}')}">
+                    <f:if condition="{dpf:inArray(needle:'{entry._id}', array:'{alreadyImported}')}">
                         <f:then>
                             <f:link.action action="import" arguments="{documentObjectIdentifier : '', objectState: ''}"
                                            class="btn btn-xs btn-info disabled">

--- a/Resources/Private/Templates/Search/DoubletCheck.html
+++ b/Resources/Private/Templates/Search/DoubletCheck.html
@@ -92,7 +92,7 @@
         </tr>
 
         <f:for each="{searchList}" as="entry">
-            <f:if condition="{dpf:inArray(needle:'{entry._source.PID}' array:'{alreadyImported}')}">
+            <f:if condition="{dpf:inArray(needle:'{entry._source.PID}', array:'{alreadyImported}')}">
                 <f:then>
                     <tr class="success">
                 </f:then>
@@ -137,7 +137,7 @@
                     </f:else>
                 </f:if>
 
-                <f:if condition="{dpf:inArray(needle:'{entry._source.PID}' array:'{alreadyImported}')}">
+                <f:if condition="{dpf:inArray(needle:'{entry._source.PID}', array:'{alreadyImported}')}">
                     <f:then>
                         <f:link.action action="import" arguments="{documentObjectIdentifier : '', objectState: ''}"
                                        class="btn btn-xs btn-info disabled">


### PR DESCRIPTION
In TYPO3 8 the missing comma leeds to a fluid parse error in template.