### PR TITLE
Fix for TYPO3 8: Broken view in manager list.

### DIFF
--- a/Classes/ViewHelpers/Link/DataCiteViewHelper.php
+++ b/Classes/ViewHelpers/Link/DataCiteViewHelper.php
@@ -31,6 +31,13 @@ class DataCiteViewHelper extends AbstractBackendViewHelper
     protected $documentRepository;
 
     /**
+     * escapeOutput, activates / deactivates HTML escaping.
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
      * Returns the View Icon with link
      * @param  integer $viewPage Detail View page id
      * @param  integer $apiPid

--- a/Classes/ViewHelpers/Link/PreviewViewHelper.php
+++ b/Classes/ViewHelpers/Link/PreviewViewHelper.php
@@ -43,6 +43,15 @@ class PreviewViewHelper extends AbstractBackendViewHelper
      */
     private $secretKey;
 
+
+    /**
+     * escapeOutput, activates / deactivates HTML escaping.
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+
     /**
      * Initialize secret key from plugin TYPOScript configuration.
      */


### PR DESCRIPTION
The HTML escaping by htmlspecialchars of the returned content must be explicitly disabled.