### PR TITLE
CMR-673

### DIFF
--- a/Classes/Plugins/MetaTags/MetaTags.php
+++ b/Classes/Plugins/MetaTags/MetaTags.php
@@ -158,7 +158,7 @@ class MetaTags extends \tx_dlf_plugin
                     if (is_array($values)) {
 
                         // Provide full dates in the "2010/5/12" format if available; or a year alone otherwise.
-                        $outArray['citation_publication_date'][] = date('Y/m/d', strtotime($values[0]));
+                        $outArray['citation_online_date'][] = date('Y/m/d', strtotime($values[0]));
 
                     }
 

--- a/Classes/Plugins/MetaTags/MetaTags.php
+++ b/Classes/Plugins/MetaTags/MetaTags.php
@@ -164,6 +164,16 @@ class MetaTags extends \tx_dlf_plugin
 
                     break;
 
+                case 'publication_date':
+
+                    if (is_array($values)) {
+
+                        $outArray['citation_publication_date'][] = date('Y', strtotime($values[0]));
+
+                    }
+
+                    break;
+
                 case 'record_id':
 
                     // Build typolink configuration array.


### PR DESCRIPTION
This PR fixes a problem with the wrong date in the `citation_publication_date` by using the correct field for the information. The previously used date is now in the `citation_online_date`-MetaTag.

So far, I only want the year for the `citation_publication_date` because that's our use case and formatting differently would give me a wrong date since I only have the year available. We might have to expand that to a full date if we enter a date with more components in the future.