### PR TITLE
[DO-102] Add process number to document list

### DIFF
--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -319,6 +319,10 @@
 			<source>Dateset Identifier</source>
 			<target>Dateset Identifier</target>
 		</trans-unit>
+		<trans-unit id="manager.document.processNumber" approved="yes">
+			<source>Process Number</source>
+			<target>Vorgangsnummer</target>
+		</trans-unit>
 		<trans-unit id="manager.document.publishedDate" approved="yes">
 			<source>Published Date</source>
 			<target>Veröffentlichungsdatum</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -239,6 +239,9 @@
 		<trans-unit id="manager.document.datasetIdentifier">
 			<source>Dateset Identifier</source>
 		</trans-unit>
+		<trans-unit id="manager.document.processNumber">
+			<source>Process Number</source>
+		</trans-unit>
 		<trans-unit id="manager.document.publishedDate">
 			<source>Published Date</source>
 		</trans-unit>

--- a/Resources/Private/Partials/Document/List.html
+++ b/Resources/Private/Partials/Document/List.html
@@ -31,6 +31,7 @@
     <tr>
         <th class="xcol-md-4">{f:translate(key: 'manager.document.title')}</th>
         <th class="xcol-md-2">{f:translate(key: 'manager.document.authors')}</th>
+        <th class="xcol-md-3">{f:translate(key: 'manager.document.processNumber')}</th>
         <th class="xcol-md-2">{f:translate(key: 'manager.document.publishedDate')}</th>
         <th class="xcol-md-2">{f:translate(key: 'manager.document.datasetIdentifier')}</th>
         <th class="xcol-md-2">{f:translate(key: 'manager.document.state')}</th>
@@ -53,6 +54,9 @@
                         <f:else>;</f:else>
                     </f:if>
                 </f:for>
+            </td>
+             <td>
+               {document.processNumber}
             </td>
             <td>
                 <f:if condition="{document.dateIssued}">


### PR DESCRIPTION
This PR adds the process number of documents to the document list in the Manager.

![Screenshot 2019-10-05 at 15 35 35](https://user-images.githubusercontent.com/180686/66255657-91d80c80-e786-11e9-857b-2bfc9106f73c.png)

This helps to distinguish document templates from real documents in the day-to-day work. Also it enables searching for specific documents via `STRG + F` in the browser if only the process number is available.