### PR TITLE
[DO-126] Add functionality to convert documents into templates

### DIFF
--- a/Classes/Controller/DocumentController.php
+++ b/Classes/Controller/DocumentController.php
@@ -53,7 +53,7 @@ class DocumentController extends \EWW\Dpf\Controller\AbstractController
      */
     public function listAction()
     {
-        $documents = $this->documentRepository->findAll();
+        $documents = $this->documentRepository->getAllDocuments();
 
         if ($this->request->hasArgument('message')) {
             $this->view->assign('message', $this->request->getArgument('message'));

--- a/Classes/Controller/DocumentController.php
+++ b/Classes/Controller/DocumentController.php
@@ -78,6 +78,12 @@ class DocumentController extends \EWW\Dpf\Controller\AbstractController
         $this->view->assign('documents', $documents);
     }
 
+     public function listTemplatesAction()
+    {
+        $documents = $this->documentRepository->getTemplates();
+        $this->view->assign('documents', $documents);
+    }
+
     /**
      * action discardConfirm
      *

--- a/Classes/Controller/DocumentController.php
+++ b/Classes/Controller/DocumentController.php
@@ -148,6 +148,7 @@ class DocumentController extends \EWW\Dpf\Controller\AbstractController
             $newDocument->setXmlData($mods->getModsXml());
 
             $newDocument->setDocumentType($document->getDocumentType());
+            $newDocument->setTemplate(false);
 
             $processNumberGenerator = $this->objectManager->get(ProcessNumberGenerator::class);
             $processNumber = $processNumberGenerator->getProcessNumber();
@@ -183,6 +184,29 @@ class DocumentController extends \EWW\Dpf\Controller\AbstractController
         $this->flashMessage($document, $key, $severity);
 
         $this->redirect('list');
+    }
+
+    /**
+     * action template
+     *
+     * @param \EWW\Dpf\Domain\Model\Document $document
+     * @return void
+     */
+    public function templateAction(\EWW\Dpf\Domain\Model\Document $document)
+    {
+
+        $wasTemplate = empty($document->isTemplate())?1:0;
+
+        $document->setTemplate($wasTemplate);
+
+        $this->documentRepository->update($document);
+
+        if($wasTemplate){
+          $this->redirect('listTemplates');
+        } else {
+          $this->redirect('list');
+        }
+
     }
 
     /**

--- a/Classes/Controller/DocumentController.php
+++ b/Classes/Controller/DocumentController.php
@@ -192,16 +192,14 @@ class DocumentController extends \EWW\Dpf\Controller\AbstractController
      * @param \EWW\Dpf\Domain\Model\Document $document
      * @return void
      */
-    public function templateAction(\EWW\Dpf\Domain\Model\Document $document)
+    public function convertTemplateAction(\EWW\Dpf\Domain\Model\Document $document)
     {
 
-        $wasTemplate = empty($document->isTemplate())?1:0;
-
-        $document->setTemplate($wasTemplate);
+        $oldTemplateStatus = $document->toggleTemplateStatus();
 
         $this->documentRepository->update($document);
 
-        if($wasTemplate){
+        if($oldTemplateStatus == false){
           $this->redirect('listTemplates');
         } else {
           $this->redirect('list');

--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -105,6 +105,13 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     protected $valid = false;
 
     /**
+     * isTemplate
+     *
+     * @var boolean
+     */
+    protected $isTemplate = false;
+
+    /**
      *
      * @var string $dateIssued
      */
@@ -610,6 +617,27 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     public function setValid($valid)
     {
         $this->valid = $valid;
+    }
+
+    /**
+     * Returns the template status
+     *
+     * @return boolean $isTemplate
+     */
+    public function isTemplate()
+    {
+        return $this->isTemplate;
+    }
+
+    /**
+     * Sets the template status
+     *
+     * @param boolean $isTemplate
+     * @return void
+     */
+    public function setTemplate($isTemplate)
+    {
+        $this->isTemplate = $isTemplate;
     }
 
     /**

--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -491,9 +491,7 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
         if (is_a($this->getFile(), '\TYPO3\CMS\Extbase\Persistence\ObjectStorage')) {
             foreach ($this->getFile() as $file) {
-
                 if (!$file->isFileGroupDeleted()) {
-
                     $tmpFile = array(
                         'path'      => $file->getLink(),
                         'type'      => $file->getContentType(),
@@ -521,7 +519,6 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
                         $files[$grpUSE][$file->getUid()] = $tmpFile;
                     }
                 }
-
             }
         }
 
@@ -542,7 +539,6 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
 
         if (is_a($this->getFile(), '\TYPO3\CMS\Extbase\Persistence\ObjectStorage')) {
             foreach ($this->getFile() as $file) {
-
                 $tmpFile = array(
                     'path'      => $file->getLink(),
                     'type'      => $file->getContentType(),
@@ -569,12 +565,10 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
                     $tmpFile['use']                  = ($file->getArchive()) ? 'ARCHIVE' : '';
                     $files[$grpUSE][$file->getUid()] = $tmpFile;
                 }
-
             }
         }
 
         return $files;
-
     }
 
     /**
@@ -816,5 +810,4 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
         $mods = new \EWW\Dpf\Helper\Mods($this->getXmlData());
         return $mods->getQucosaUrn();
     }
-
 }

--- a/Classes/Domain/Model/Document.php
+++ b/Classes/Domain/Model/Document.php
@@ -624,6 +624,19 @@ class Document extends \TYPO3\CMS\Extbase\DomainObject\AbstractEntity
     }
 
     /**
+     * Toogles the template status and returns the old value
+     *
+     * @return boolean
+     */
+    public function toggleTemplateStatus()
+    {
+        $oldTemplateStatus = $this->isTemplate;
+        $this->isTemplate = !$oldTemplateStatus;
+        return $oldTemplateStatus;
+    }
+
+
+    /**
      * Sets the template status
      *
      * @param boolean $isTemplate

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -29,7 +29,7 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
         $constraints = array(
             $query->logicalNot($query->equals('object_identifier', '')),
-            $query->logicalNot($query->equals('object_identifier', NULL)));
+            $query->logicalNot($query->equals('object_identifier', null)));
 
         if (count($constraints)) {
             $query->matching($query->logicalAnd($constraints));
@@ -161,11 +161,11 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     public function findDocumentsWithoutProcessNumber()
     {
         $query = $this->createQuery();
-        $query->getQuerySettings()->setRespectStoragePage(FALSE);
+        $query->getQuerySettings()->setRespectStoragePage(false);
 
         $constraints = array();
         $constraints[] =  $query->equals('process_number', '');
-        $constraints[] =  $query->equals('process_number', NULL);
+        $constraints[] =  $query->equals('process_number', null);
 
         if (count($constraints)) {
             $query->matching($query->logicalOr($constraints));
@@ -173,5 +173,4 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
         return $query->execute();
     }
-
 }

--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -51,6 +51,31 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
      *
      * @return array The found Document Objects
      */
+    public function getAllDocuments()
+    {
+
+        $query = $this->createQuery();
+
+        $constraints = array(
+                $query->equals('is_template', false));
+
+        if (count($constraints)) {
+            $query->matching($query->logicalAnd($constraints));
+        }
+
+        // order by start_date -> start_time...
+        $query->setOrderings(
+            array('transfer_date' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING)
+        );
+
+        return $query->execute();
+    }
+
+    /**
+     * Finds all new documents
+     *
+     * @return array The found Document Objects
+     */
     public function getNewDocuments()
     {
 
@@ -58,7 +83,8 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
         $constraints = array(
                 $query->equals('object_identifier', ''),
-                $query->equals('changed', false));
+                $query->equals('changed', false),
+                $query->equals('is_template', false));
 
         if (count($constraints)) {
             $query->matching($query->logicalAnd($constraints));
@@ -81,14 +107,46 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
     {
 
         $query = $this->createQuery();
-        
-        $constraints = array(
+
+        $orConstraints = array(
                 $query->like('object_identifier', 'qucosa%'),
                 $query->equals('changed', true));
 
-        if (count($constraints)) {
-            $query->matching($query->logicalOr($constraints));
+        if (count($orConstraints)) {
+            $query->matching($query->logicalOr($orConstraints));
         }
+
+        $andConstraints = array(
+          $query->like('is_template', false));
+
+        if (count($andConstraints)) {
+            $query->matching($query->logicalAnd($andConstraints));
+        }
+
+        return $query->execute();
+    }
+
+    /**
+     * Finds all templates
+     *
+     * @return array The found Document Objects
+     */
+    public function getTemplates()
+    {
+
+        $query = $this->createQuery();
+
+        $constraints = array(
+                $query->equals('is_template', true));
+
+        if (count($constraints)) {
+            $query->matching($query->logicalAnd($constraints));
+        }
+
+        // order by start_date -> start_time...
+        $query->setOrderings(
+            array('transfer_date' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING)
+        );
 
         return $query->execute();
     }

--- a/Configuration/TCA/tx_dpf_domain_model_document.php
+++ b/Configuration/TCA/tx_dpf_domain_model_document.php
@@ -39,12 +39,12 @@ return array(
     ),
     'interface' => array(
         'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden,
-        title, authors, xml_data, slub_info_data, document_type, date_issued, process_number, valid, changed,
+        title, authors, xml_data, slub_info_data, document_type, date_issued, process_number, valid, changed, is_template,
         state, reserved_object_identifier, object_identifier, transfer_status, file',
     ),
     'types'     => array(
-        '1' => array('showitem' => 'sys_language_uid,l10n_parent,l10n_diffsource,hidden,--palette--;;1, 
-        title, authors, xml_data, slub_info_data, document_type, date_issued, process_number, valid, changed,
+        '1' => array('showitem' => 'sys_language_uid,l10n_parent,l10n_diffsource,hidden,--palette--;;1,
+        title, authors, xml_data, slub_info_data, document_type, date_issued, process_number, valid, changed, is_template,
         state, reserved_object_identifier, object_identifier, transfer_status, file,
         --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
     ),
@@ -274,6 +274,16 @@ return array(
             'exclude'   => 1,
             'l10n_mode' => 'exclude',
             'label'     => 'LLL:EXT:dpf/Resources/Private/Language/locallang_db.xlf:tx_dpf_domain_model_document.valid',
+            'config'    => array(
+                'type'    => 'check',
+                'default' => 0,
+            ),
+        ),
+
+        'is_template'                   => array(
+            'exclude'   => 1,
+            'l10n_mode' => 'exclude',
+            'label'     => 'LLL:EXT:dpf/Resources/Private/Language/locallang_db.xlf:tx_dpf_domain_model_document.template',
             'config'    => array(
                 'type'    => 'check',
                 'default' => 0,

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -339,6 +339,10 @@
 			<source>New</source>
 			<target>Neu</target>
 		</trans-unit>
+		<trans-unit id="manager.document.templates" approved="yes">
+			<source>Templates</source>
+			<target>Vorlagen</target>
+		</trans-unit>
 		<trans-unit id="manager.document.title" approved="yes">
 			<source>Title</source>
 			<target>Titel</target>

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -283,7 +283,7 @@
 		</trans-unit>
 		<trans-unit id="manager.deleteConfirmMessage" approved="yes" xml:space="preserve">
 			<source>The document &quot;%s&quot; will be marked as deleted in the repository and the local document will be discarded, all local changes are rejected.</source>
-			<target>Das Dokument &quot;%s&quot; wird im Repository als gelöscht markiert und das lokale Dokument und alle Änderungen werden verworfen. 
+			<target>Das Dokument &quot;%s&quot; wird im Repository als gelöscht markiert und das lokale Dokument und alle Änderungen werden verworfen.
 
 </target>
 		</trans-unit>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -163,11 +163,11 @@
 		</trans-unit>
 		<trans-unit id="tx_dpf_domain_model_document.valid">
 			<source>Valid</source>
-            <target>Gültig</target>
+			<target>Gültig</target>
 		</trans-unit>
 		<trans-unit id="tx_dpf_domain_model_document.changed">
 			<source>Changed</source>
-            <target>Geändert</target>
+			<target>Geändert</target>
 		</trans-unit>
 		<trans-unit id="tx_dpf_domain_model_document.file">
 			<source>File</source>

--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -173,6 +173,10 @@
 			<source>File</source>
 			<target>Datei</target>
 		</trans-unit>
+		<trans-unit id="tx_dpf_domain_model_document.template">
+			<source>Template</source>
+			<target>Vorlage</target>
+		</trans-unit>
 		<trans-unit id="tx_dpf_domain_model_documenttransferlog" approved="yes">
 			<source>Document Transfer Log</source>
 			<target>Dokumentenübertragungsprotokoll</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -254,6 +254,9 @@
 		<trans-unit id="manager.document.state.new">
 			<source>New</source>
 		</trans-unit>
+		<trans-unit id="manager.document.templates">
+			<source>Templates</source>
+		</trans-unit>
 		<trans-unit id="manager.document.title">
 			<source>Title</source>
 		</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -131,6 +131,9 @@
 		<trans-unit id="tx_dpf_domain_model_document.file">
 			<source>File</source>
 		</trans-unit>
+		<trans-unit id="tx_dpf_domain_model_document.template">
+			<source>Template</source>
+		</trans-unit>
 		<trans-unit id="tx_dpf_domain_model_documenttransferlog">
 			<source>Document Transfer Log</source>
 		</trans-unit>

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -299,12 +299,12 @@
 		<trans-unit id="tx_dpf_domain_model_metadataobject.fill_out_service.urn">
 			<source>URN</source>
 		</trans-unit>
-        <trans-unit id="tx_dpf_domain_model_metadataobject.fill_out_service.gnd">
-            <source>GND</source>
-        </trans-unit>
-        <trans-unit id="tx_dpf_domain_model_metadataobject.gnd_field_uid">
-            <source>GND No. field UID</source>
-        </trans-unit>
+		<trans-unit id="tx_dpf_domain_model_metadataobject.fill_out_service.gnd">
+			<source>GND</source>
+		</trans-unit>
+		<trans-unit id="tx_dpf_domain_model_metadataobject.gnd_field_uid">
+			<source>GND No. field UID</source>
+		</trans-unit>
 		<trans-unit id="tx_dpf_domain_model_metadataobject.input_field">
 			<source>Input Field</source>
 		</trans-unit>

--- a/Resources/Private/Partials/Document/List.html
+++ b/Resources/Private/Partials/Document/List.html
@@ -124,7 +124,7 @@
                     </f:link.action>
                 </f:alias>
 
-                <f:link.action action="template" arguments="{document : document}" class="btn btn-xs btn-default"
+                <f:link.action action="convertTemplate" arguments="{document : document}" class="btn btn-xs btn-default"
                                 title="{f:translate(key: 'manager.tooltip.template')}">
 
                 <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span> In Vorlage konvertieren

--- a/Resources/Private/Partials/Document/List.html
+++ b/Resources/Private/Partials/Document/List.html
@@ -23,6 +23,10 @@
                    class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document', actionName:'listEdit')}">
         {f:translate(key: 'manager.document.state.inProgress')}
     </f:link.action>
+     <f:link.action action="listTemplates" controller="Document"
+                   class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document', actionName:'listTemplates')}">
+        {f:translate(key: 'manager.document.templates')}
+    </f:link.action>
 </div>
 
 

--- a/Resources/Private/Partials/Document/List.html
+++ b/Resources/Private/Partials/Document/List.html
@@ -124,6 +124,12 @@
                     </f:link.action>
                 </f:alias>
 
+                <f:link.action action="template" arguments="{document : document}" class="btn btn-xs btn-default"
+                                title="{f:translate(key: 'manager.tooltip.template')}">
+
+                <span class="glyphicon glyphicon-list-alt" aria-hidden="true"></span> In Vorlage konvertieren
+                                 </f:link.action>
+
                 <f:link.action action="discard" arguments="{document : document}" class="btn btn-xs btn-warning"
                                additionalAttributes="{data-documenttitle: document.title,data-toggle: 'modal',data-target: '#confirmDiscard'}">
                     <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>

--- a/Resources/Private/Partials/Document/List.html
+++ b/Resources/Private/Partials/Document/List.html
@@ -33,7 +33,7 @@
 <table class="tx_dpf table table-striped table-manager table-condensed">
     <thead>
     <tr>
-        <th class="xcol-md-4">{f:translate(key: 'manager.document.title')}</th>
+        <th class="xcol-md-4 title">{f:translate(key: 'manager.document.title')}</th>
         <th class="xcol-md-2">{f:translate(key: 'manager.document.authors')}</th>
         <th class="xcol-md-3">{f:translate(key: 'manager.document.processNumber')}</th>
         <th class="xcol-md-2">{f:translate(key: 'manager.document.publishedDate')}</th>

--- a/Resources/Private/Partials/Document/ListTemplates.html
+++ b/Resources/Private/Partials/Document/ListTemplates.html
@@ -89,7 +89,7 @@
                 <span class="glyphicon glyphicon-duplicate"></span>
               </f:link.action>
 
-              <f:link.action action="template" arguments="{document : document}" class="btn btn-xs btn-default"
+              <f:link.action action="convertTemplate" arguments="{document : document}" class="btn btn-xs btn-default"
                              title="{f:translate(key: 'manager.tooltip.template')}">
                 <span class="glyphicon glyphicon-file" aria-hidden="true"></span> In Dokument konvertieren
               </f:link.action>

--- a/Resources/Private/Partials/Document/ListTemplates.html
+++ b/Resources/Private/Partials/Document/ListTemplates.html
@@ -1,0 +1,128 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+{namespace dpf = EWW\Dpf\ViewHelpers}
+
+<div class="btn-group" role="group">
+    <f:link.action action="listNew" controller="Document"
+                   class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document', actionName:'listNew')}">
+        {f:translate(key: 'manager.document.state.new')}
+    </f:link.action>
+    <f:link.action action="listEdit" controller="Document"
+                   class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document', actionName:'listEdit')}">
+        {f:translate(key: 'manager.document.state.inProgress')}
+    </f:link.action>
+     <f:link.action action="listTemplates" controller="Document"
+                   class="btn btn-default btn-sm {dpf:activeManagerMenu(controllerName:'Document', actionName:'listTemplates')}">
+        {f:translate(key: 'manager.document.templates')}
+    </f:link.action>
+</div>
+
+
+<table class="tx_dpf table table-striped table-manager table-condensed">
+    <thead>
+    <tr>
+        <th class="xcol-md-4 title">{f:translate(key: 'manager.document.title')}</th>
+        <th class="xcol-md-2">{f:translate(key: 'manager.document.authors')}</th>
+        <th class="xcol-md-3">{f:translate(key: 'manager.document.processNumber')}</th>
+        <th class="xcol-md-2">{f:translate(key: 'manager.document.publishedDate')}</th>
+        <th class="xcol-md-2">{f:translate(key: 'manager.document.datasetIdentifier')}</th>
+        <th class="xcol-md-2">{f:translate(key: 'manager.document.state')}</th>
+        <th class="xcol-md-2">{f:translate(key: 'manager.document.type')}</th>
+        <th class="xcol-md-2"><!-- ACTIONS --></th>
+    </tr>
+    </thead>
+    <f:for each="{documents}" as="document">
+        <tr>
+            <td>
+                <f:link.action action="edit" controller="DocumentFormBE" arguments="{document : document}">
+                    {document.title}
+                </f:link.action>
+            </td>
+            <td>
+                <f:for each="{document.authors}" as="author" iteration="itemIterator">
+                    {author}
+                    <f:if condition="{itemIterator.isLast}">
+                        <f:then></f:then>
+                        <f:else>;</f:else>
+                    </f:if>
+                </f:for>
+            </td>
+             <td>
+               {document.processNumber}
+            </td>
+            <td>
+                <f:if condition="{document.dateIssued}">
+                    <f:format.date date="{document.dateIssued}" format="d.m.Y"/>
+                </f:if>
+            </td>
+            <td>{document.objectIdentifier}</td>
+            <td>
+                <f:if condition="{document.isNew}">
+                    <f:then>
+                        {f:translate(key: 'manager.document.state.new')}
+                    </f:then>
+                    <f:else>
+                        {f:translate(key: 'manager.document.state.inProgress')}
+                    </f:else>
+                </f:if>
+            </td>
+            <td>
+                {document.documentType.displayName}
+            </td>
+            <td class="table_col_function">
+
+              <f:link.action action="duplicate" arguments="{document : document}" class="btn btn-xs btn-default"
+                             title="{f:translate(key: 'manager.tooltip.duplicate')}"
+                             additionalAttributes="{data-toggle: 'tooltip' }">
+                <span class="glyphicon glyphicon-duplicate"></span>
+              </f:link.action>
+
+              <f:link.action action="template" arguments="{document : document}" class="btn btn-xs btn-default"
+                             title="{f:translate(key: 'manager.tooltip.template')}">
+                <span class="glyphicon glyphicon-file" aria-hidden="true"></span> In Dokument konvertieren
+              </f:link.action>
+
+              <f:link.action action="discard" arguments="{document : document}" class="btn btn-xs btn-warning"
+                             additionalAttributes="{data-documenttitle: document.title,data-toggle: 'modal',data-target: '#confirmDiscard'}">
+                <span class="glyphicon glyphicon-trash" aria-hidden="true"></span>
+                    {f:translate(key: 'manager.discard')}
+                </f:link.action>
+            </td>
+        </tr>
+    </f:for>
+</table>
+
+<div class="modal fade" id="confirmDiscard" tabindex="-1" aria-hidden="true" role="dialog">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal"
+                        aria-label="{f:translate(key: 'manager.discardConfirmNo')}"><span
+                        aria-hidden="true">&times;</span></button>
+                <h4 class="modal-title">{f:translate(key: 'manager.discardConfirmMessageHeader')}</h4>
+            </div>
+            <div class="modal-body">
+                <p>{f:translate(key: 'manager.discardConfirmMessage', arguments: {0: '%s'})}</p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">{f:translate(key:
+                    'manager.discardConfirmNo')}
+                </button>
+                <a id="discardDocument" class="btn btn-danger" href="#">{f:translate(key:
+                    'manager.discardConfirmYes')}</a>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Resources/Private/Templates/Document/ListTemplates.html
+++ b/Resources/Private/Templates/Document/ListTemplates.html
@@ -1,0 +1,19 @@
+<f:comment>
+    <!--
+    This file is part of the TYPO3 CMS project.
+
+    It is free software; you can redistribute it and/or modify it under
+    the terms of the GNU General Public License, either version 2
+    of the License, or any later version.
+
+    For the full copyright and license information, please read the
+    LICENSE.txt file that was distributed with this source code.
+
+    The TYPO3 project - inspiring people to share!
+    -->
+</f:comment>
+<f:layout name="DefaultBE"/>
+
+<f:section name="main">
+    <f:render partial="Document/ListTemplates" arguments="{documents:documents}"/>
+</f:section>

--- a/Resources/Public/CSS/manager.css
+++ b/Resources/Public/CSS/manager.css
@@ -101,6 +101,10 @@ table.tx_dpf .table_col_function {
     padding: 8px 15px 8px 0;
 }
 
+table.tx_dpf th.title {
+  width: 300px;
+}
+
 table.tx_dpf .table_col_function a {
     text-decoration: none;
 }

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -51,7 +51,7 @@ if (TYPO3_MODE === 'BE') {
         'qucosamanager',
         '',
         array(
-            'Document'         => 'list, delete, discard, release, duplicate, template,'
+            'Document'         => 'list, delete, discard, release, duplicate, convertTemplate,'
             . 'deleteConfirm, releaseConfirm, activateConfirm, inactivateConfirm, deleteConfirm, discardConfirm, restoreConfirm, '
             . 'listNew, listEdit, listTemplates, activate, inactivate, restore',
 
@@ -67,7 +67,7 @@ if (TYPO3_MODE === 'BE') {
             'navigationComponentId' => 'typo3-pagetree',
         )
     );
-    
+
 }
 
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -51,9 +51,9 @@ if (TYPO3_MODE === 'BE') {
         'qucosamanager',
         '',
         array(
-            'Document'         => 'list, delete, discard, release, duplicate, '
+            'Document'         => 'list, delete, discard, release, duplicate, template,'
             . 'deleteConfirm, releaseConfirm, activateConfirm, inactivateConfirm, deleteConfirm, discardConfirm, restoreConfirm, '
-            . 'listNew, listEdit, activate, inactivate, restore',
+            . 'listNew, listEdit, listTemplates, activate, inactivate, restore',
 
             'DocumentFormBE'   => 'list, show, new, create, edit, update, delete, cancel',
             'AjaxDocumentForm' => 'group,fileGroup,field,deleteFile,primaryUpload,secondaryUpload,fillOut',

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -75,6 +75,8 @@ CREATE TABLE tx_dpf_domain_model_document (
   date_issued varchar(255) DEFAULT '' NOT NULL,
   changed tinyint(1) unsigned DEFAULT '0' NOT NULL,
   valid tinyint(1) unsigned DEFAULT '0' NOT NULL,
+  is_template tinyint(1) unsigned DEFAULT '0' NOT NULL,
+
 
   file int(11) unsigned DEFAULT '0' NOT NULL,
 


### PR DESCRIPTION
This PR adds the functionality to convert documents into templates. These templates can be used to create additional documents by duplicating them. This is relevant when you have to deal with issues of newspapers when each one is mostly the same and you don't want to create a new document from scratch with identical details.

![Screenshot 2019-10-15 at 18 56 46](https://user-images.githubusercontent.com/180686/66852734-ea28be80-ef7d-11e9-8614-3807462f83af.png)

![Screenshot 2019-10-15 at 18 56 53](https://user-images.githubusercontent.com/180686/66852748-f01e9f80-ef7d-11e9-86fe-70704beda425.png)

The template status information is not stored in the meta data of the document. It's a new field in the TYPO3 database that can be used to differentiate documents from template "documents".

(This is based on the 2.x branch.)