### PR TITLE
CMR-850: Fix issue where wrong constraint was evaluated

### DIFF
--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -108,20 +108,24 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
         $query = $this->createQuery();
 
+        $constraints = array();
+
         $orConstraints = array(
                 $query->like('object_identifier', 'qucosa%'),
                 $query->equals('changed', true));
 
         if (count($orConstraints)) {
-            $query->matching($query->logicalOr($orConstraints));
+            $constraints[] = $query->logicalOr($orConstraints);
         }
 
         $andConstraints = array(
           $query->like('is_template', false));
 
         if (count($andConstraints)) {
-            $query->matching($query->logicalAnd($andConstraints));
+            $constraints[] = $query->logicalAnd($andConstraints);
         }
+
+        $query->matching($query->logicalAnd($constraints));
 
         return $query->execute();
     }


### PR DESCRIPTION
This PR fixes an issue with the query logic where only a single constraint was evaluated instead of a combination.

The query for "in progress"-documents is wrong if there is at least one template created. The list for in progress documents shows therefore all documents that aren't templates without additional restrictions.

It should show all documents that aren't templates **AND** from those only the ones that are in progress. The PR fixes this oversight.