### PR TITLE
Table tx_dpf_domain_model_processnumber is only allowed on root-level.

### DIFF
--- a/Configuration/TCA/tx_dpf_domain_model_document.php
+++ b/Configuration/TCA/tx_dpf_domain_model_document.php
@@ -46,7 +46,7 @@ return array(
         '1' => array('showitem' => 'sys_language_uid,l10n_parent,l10n_diffsource,hidden,--palette--;;1,
         title, authors, xml_data, slub_info_data, document_type, date_issued, process_number, valid, changed, is_template,
         state, reserved_object_identifier, object_identifier, transfer_status, file,
-        --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
+        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'),
     ),
     'palettes'  => array(
         '1' => array('showitem' => ''),

--- a/Configuration/TCA/tx_dpf_domain_model_documenttransferlog.php
+++ b/Configuration/TCA/tx_dpf_domain_model_documenttransferlog.php
@@ -42,7 +42,7 @@ return array(
     'types'     => array(
         '1' => array('showitem' => 'sys_language_uid,l10n_parent,l10n_diffsource,hidden,--palette--;;1,
         date, response, curl_error, document_uid, object_identifier, action,
-        --div--;LLL:EXT:cms/locallang_ttc.xlf:tabs.access, starttime, endtime'),
+        --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.access, starttime, endtime'),
     ),
     'palettes'  => array(
         '1' => array('showitem' => ''),

--- a/Configuration/TCA/tx_dpf_domain_model_processnumber.php
+++ b/Configuration/TCA/tx_dpf_domain_model_processnumber.php
@@ -35,6 +35,7 @@ return array(
         ),
         'searchFields'             => 'owner_id, year, counter',
         'iconfile'                 => 'EXT:dpf/Resources/Public/Icons/tx_dpf_domain_model_processnumber.gif',
+        'rootLevel' => 1,
     ),
     'interface' => array(
         'showRecordFieldList' => 'sys_language_uid, l10n_parent, l10n_diffsource, hidden, owner_id, year, counter'

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -100,4 +100,3 @@ if (TYPO3_MODE === 'BE') {
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_dpf_domain_model_inputoptionlist');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addLLrefForTCAdescr('tx_dpf_domain_model_processnumber', 'EXT:dpf/Resources/Private/Language/locallang_csh_tx_dpf_domain_model_processnumber.xlf');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_dpf_domain_model_processnumber');


### PR DESCRIPTION
Currently the table tx_dpf_domain_model_processnumber is only possible on root-level (uid==0). It's not possible on standard pages. The configuration is wrong and cannot be imported on fresh systems.