### PR TITLE
Update docker infrastructure

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,0 @@
-COMPOSE_PROJECT_NAME=kitodo-publication

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 nbproject/
 .idea/
 vendor/
+.env

--- a/Build/.env
+++ b/Build/.env
@@ -1,1 +1,1 @@
-COMPOSE_PROJECT_NAME=kitodo-publication
+../.env

--- a/Build/Dockerfile-TYPO3
+++ b/Build/Dockerfile-TYPO3
@@ -38,13 +38,17 @@ WORKDIR /var/www/html
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 RUN echo '{"require":{"typo3/cms":"~8.7.0"}}' > /var/www/html/composer.json && \
     composer update && \
+    composer config extra.typo3/cms.cms-package-dir '{$vendor-dir}/typo3/cms' && \
+    mkdir typo3temp && \
+    mkdir typo3conf && \
+    mkdir fileadmin && \
+    mkdir uploads && \
     touch FIRST_INSTALL && \
     chown -R www-data .
 
 FROM typo3builder
 WORKDIR /var/www/html
-RUN composer config repositories.t3ter composer https://composer.typo3.org && \
-    composer config repositories.kitodo-publication path /app && \
+RUN composer config repositories.kitodo-publication '{"type": "path", "url": "/app", "options": {"symlink": true}}' && \
     composer config minimum-stability dev && \
     composer config prefer-stable true
 RUN composer require devlog/devlog:~3.0.4 && \

--- a/Build/Dockerfile-TYPO3
+++ b/Build/Dockerfile-TYPO3
@@ -54,5 +54,6 @@ RUN composer config repositories.kitodo-publication '{"type": "path", "url": "/a
 RUN composer require devlog/devlog:~3.0.4 && \
     composer require kitodo/presentation
 COPY . /app
-RUN composer require kitodo/publication && \
+RUN composer require nimut/testing-framework && \
+    composer require kitodo/publication:@dev && \
     chown -R www-data .

--- a/Build/docker-compose.yml
+++ b/Build/docker-compose.yml
@@ -1,11 +1,9 @@
-version: '2'
+version: '3.5'
 
 services:
-    typo3-database:
+    db:
         image: mysql:5.6
-        container_name: kitodo-publication-mysql
-        command: mysqld --character-set-server=utf8  --collation-server=utf8_unicode_ci
-        hostname: db
+        command: mysqld --character-set-server=utf8 --collation-server=utf8_unicode_ci
         ports:
             - "3306:3306"
         environment:
@@ -14,35 +12,39 @@ services:
             MYSQL_PASSWORD: typo3
             MYSQL_DATABASE: typo3
         volumes:
-            - mysql-latest:/var/lib/mysql
+            - db:/var/lib/mysql
         networks:
-            frontend:
-                aliases:
-                    - db
+            - frontend
 
-    typo3-app:
+    typo3:
         build:
             context: ..
             dockerfile: Build/Dockerfile-TYPO3
         image: kitodo-publication:latest
-        container_name: kitodo-publication-typo3
-        hostname: typo3
         ports:
             - "80:80"
         volumes:
             - ..:/app
-            - website-latest:/var/www/html
+            - fileadmin:/var/www/html/fileadmin
+            - typo3temp:/var/www/html/typo3temp
+            - typo3conf:/var/www/html/typo3conf
+            - uploads:/var/www/html/uploads
         depends_on:
-            - typo3-database
+            - db
         networks:
             - frontend
-            - qucosafcrepodocker_backend
+            - backend
 
 volumes:
-    mysql-latest:
-    website-latest:
+    db:
+    fileadmin:
+    typo3temp:
+    typo3conf:
+    uploads:
 
 networks:
     frontend:
-    qucosafcrepodocker_backend:
-        external: true
+        name: kitodopublication_frontend
+    backend:
+        external:
+            name: qucosa_backend

--- a/Build/install-git-hook.sh
+++ b/Build/install-git-hook.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+cp -v post-checkout ../.git/hooks
+chmod -v +x ../.git/hooks/post-checkout

--- a/Build/post-checkout
+++ b/Build/post-checkout
@@ -1,0 +1,7 @@
+#!/bin/sh
+BRANCH=$(git symbolic-ref HEAD | cut -d '/' -f3)
+PWD=$(basename `pwd`)
+if [ ! -z "$BRANCH" ]
+then
+    echo "COMPOSE-PROJECT-NAME=$PWD-$BRANCH" > .env
+fi


### PR DESCRIPTION
Upgrade Docker and Compose files for more appropriate image building. As long as the volumes exist, the TYPO3 configuration should remain when recreating containers or even images. Also adds a Git Hook to configure COMPOSE_PROJECT_NAME variable on every checkout (changing branches) in order to separate Compose services running in different branches.