### PR TITLE
Enable reading XLink nodes from MODS

### DIFF
--- a/Classes/Services/MetsExporter.php
+++ b/Classes/Services/MetsExporter.php
@@ -111,6 +111,7 @@ class MetsExporter
             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
             xmlns:foaf="http://xmlns.com/foaf/0.1/"
             xmlns:person="http://www.w3.org/ns/person#"
+            xmlns:xlink="https://www.w3.org/1999/xlink"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd"
             version="3.7">';
 

--- a/Tests/Unit/Services/XPathXMLGeneratorTest.php
+++ b/Tests/Unit/Services/XPathXMLGeneratorTest.php
@@ -79,6 +79,22 @@ class XPathXMLGeneratorTest extends UnitTestCase
     /**
      * @test
      */
+    public function testAttributeWithNamespacePrefix()
+    {
+        $xpath = 'mods:accessCondition[@xlink:href="http://example.org"]';
+        $expectedXml = '<mods:accessCondition xlink:href="http://example.org"/>';
+
+        $this->xpathGenerator->generateXmlFromXPath($xpath);
+
+        $this->assertEquals(
+            $expectedXml,
+            $this->xpathGenerator->getXML()
+        );
+    }
+
+    /**
+     * @test
+     */
     public function testValuesWithLinebreaks()
     {
         $xpath = "mods:originInfo[@eventType='publication']=\"A\nB\nC\n\"";


### PR DESCRIPTION
Form configurations need to use XLink attributes. The namespace for XLink and the `xlink` prefix need to be declared in MODS documents.