### PR TITLE
[3.x] Change ordering of document lists in the backend

### DIFF
--- a/Classes/Domain/Repository/DocumentRepository.php
+++ b/Classes/Domain/Repository/DocumentRepository.php
@@ -63,9 +63,8 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
             $query->matching($query->logicalAnd($constraints));
         }
 
-        // order by start_date -> start_time...
         $query->setOrderings(
-            array('transfer_date' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING)
+            array('uid' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING)
         );
 
         return $query->execute();
@@ -90,9 +89,8 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
             $query->matching($query->logicalAnd($constraints));
         }
 
-        // order by start_date -> start_time...
         $query->setOrderings(
-            array('transfer_date' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING)
+            array('uid' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING)
         );
 
         return $query->execute();
@@ -127,6 +125,10 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
 
         $query->matching($query->logicalAnd($constraints));
 
+        $query->setOrderings(
+            array('uid' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING)
+        );
+
         return $query->execute();
     }
 
@@ -147,9 +149,8 @@ class DocumentRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
             $query->matching($query->logicalAnd($constraints));
         }
 
-        // order by start_date -> start_time...
         $query->setOrderings(
-            array('transfer_date' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_ASCENDING)
+            array('uid' => \TYPO3\CMS\Extbase\Persistence\QueryInterface::ORDER_DESCENDING)
         );
 
         return $query->execute();


### PR DESCRIPTION
The PR changes the ordering of the document lists in the backend. It's now sorted by `uid` of the TYPO3 database. Newer documents (in the "DB-insert" sense) should now appear at the top.

Additionally, the `inProgess`-List was not sorted at all before so the order should be consistent now.
