### PR TITLE
[CMR-824][3.x] Encode html entities in metatag values

### DIFF
--- a/Classes/Plugins/MetaTags/MetaTags.php
+++ b/Classes/Plugins/MetaTags/MetaTags.php
@@ -174,7 +174,7 @@ class MetaTags extends \Kitodo\Dlf\Common\AbstractPlugin
         foreach ($outArray as $tagName => $values) {
             foreach ($values as $value) {
                 $pageRenderer = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Page\PageRenderer::class);
-                $pageRenderer->addMetaTag('<meta name="' . $tagName . '" content="' . $value . '">');
+                $pageRenderer->addMetaTag('<meta name="' . $tagName . '" content="' . htmlspecialchars($value) . '">');
             }
         }
         return $output;


### PR DESCRIPTION
This prevents (among other things) double quotes leaking in the HTML output and breaking the tags by correctly encoding HTML entities before writing the output.

I could not generate these cases in the backend but a quick test to verify is simply setting the meta tag `$value` in code directly before the output to something like `$value='"TestMitUmlauten&Anführungszeichen"';`. Without the `htmlspecialchars` the source is broken due to the nesting of double quotes. 