### PR TITLE
[3.x] Fix hidden error message

### DIFF
--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -395,6 +395,11 @@ ul.error-files-backbutton li {
     list-style: none;
 }
 
+.tx-dpf form .alert {
+    position: relative;
+    top: 60px;
+}
+
     /* -- extended search form--------------------------------------------------- */
 
 .tx-dpf div.searchExtForm div.container {

--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -235,7 +235,7 @@ var validateForm = function() {
 }
 var showFormError = function() {
     jQuery('.tx-dpf div.alert-danger').remove();
-    jQuery('<div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon glyphicon-fire pull-right"></span>' + form_error_msg + '</div>').insertBefore(jQuery('.tx-dpf form').first());
+    jQuery('<div class="alert alert-danger" role="alert"><span class="glyphicon glyphicon glyphicon-fire pull-right"></span>' + form_error_msg + '</div>').insertAfter(jQuery('.tx-dpf form .tx-dpf-tab-container').first());
     jQuery("html, body").animate({
         scrollTop: 0
     }, 200);


### PR DESCRIPTION
This PR resolves #169.

I changed the insertion point of the error message in the DOM and adjusted its position so it stays visible below the navigation. The layout is not perfect for all publication types due to the navigation having different amounts of tabs (and therefore height) but at least it's not hidden anymore. :)

**Before:**

<img width="624" alt="image" src="https://user-images.githubusercontent.com/180686/82941532-c9eec280-9f96-11ea-9184-196d305b1d61.png">

**After:**

<img width="618" alt="image" src="https://user-images.githubusercontent.com/180686/82941379-8ac07180-9f96-11ea-86f9-96eb1d4b4c26.png">