### PR TITLE
[3.x] Fix select overlay issue

### DIFF
--- a/Resources/Private/Partials/DocumentForm/Field.html
+++ b/Resources/Private/Partials/DocumentForm/Field.html
@@ -85,7 +85,7 @@
                              additionalAttributes="{data-field:fieldItem.uid,data-index:fieldIndex,data-mandatory:fieldItem.mandatory,data-group:formGroupUid,data-groupindex:groupIndex,data-default:fieldItem.hasDefaultValue,data-regexp:fieldItem.validation,data-datatype:fieldItem.dataType,data-label:fieldItem.displayName,data-maxlength:fieldItem.maxInputLength}"/>
         </f:case>
         <f:case value="2">
-            <div class="form-control has-select">
+            <div class="form-control has-select {f:if(condition: '{fieldItem.maxIteration} == 0', then: 'has-button', else: '')}">
                 <f:form.select id="inp_{fieldItem.uid}"
                                property="metadata.{formPageUid}-{formGroupUid}-{groupIndex}-{fieldItem.uid}-{fieldIndex}"
                                value="{fieldItem.value}" class="form-control input-field {fieldItem.fillOutService}"

--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -171,11 +171,6 @@
     box-shadow: none;
 }
 
-.tx-dpf .form-group .form-control.has-select {
-    border-color: #eee #eee #eee #ccc;
-    box-shadow: none;
-}
-
 .tx-dpf .form-group .form-control select {
     width: 100%;
     height: 100%;

--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -299,9 +299,9 @@
     left: 1px;
 }
 
-.tx-dpf .glyphicon-remove {
-    top: 1.5px !important;
-    left: 0 !important;
+.tx-dpf button .glyphicon-remove {
+    top: 1.5px;
+    left: 0;
 }
 
 .tx-dpf ol li {

--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -171,11 +171,26 @@
     box-shadow: none;
 }
 
+.tx-dpf .form-group .form-control.has-select {
+    border-color: #eee #eee #eee #ccc;
+    box-shadow: none;
+}
+
 .tx-dpf .form-group .form-control select {
     width: 100%;
     height: 100%;
     padding: 0 6px;
     border: none;
+}
+
+.tx-dpf .form-container .form-group:first-child .form-control.has-button,
+.tx-dpf .form-container .form-group:first-child .form-control.has-button select {
+   width: calc(100% - 32px);
+}
+
+.tx-dpf .form-group .form-control.has-button,
+.tx-dpf .form-group .form-control.has-button select {
+   width: calc(100% - 62px);
 }
 
 .tx-dpf .form-group .form-control {

--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -304,6 +304,11 @@
     left: 1px;
 }
 
+.tx-dpf .glyphicon-remove {
+    top: 1.5px !important;
+    left: 0 !important;
+}
+
 .tx-dpf ol li {
     list-style: none;
 }


### PR DESCRIPTION
This PR fixes #171 

I added a class to select statements that will have buttons next to them and adjust the styling accordingly. Now it's possible to see clearly if your dealing with a select input element.

Also, the X-glyph is now in the middle and not drunk in the corner!

**Before the change:**

![CleanShot 2020-05-27 at 22 38 02](https://user-images.githubusercontent.com/180686/83070736-3091e000-a06c-11ea-9a96-d67c8c3b2f99.gif)

**After the change:**

![CleanShot 2020-05-27 at 22 38 29](https://user-images.githubusercontent.com/180686/83070761-37b8ee00-a06c-11ea-929f-859ed85c5d0b.gif)

This also effects the backend manager.

**Before the change:**

<img width="148" alt="CleanShot 2020-05-27 at 22 42 47@2x" src="https://user-images.githubusercontent.com/180686/83070807-4ef7db80-a06c-11ea-8d9f-5dfe7cc10f8a.png">

**After the change:**

<img width="143" alt="CleanShot 2020-05-27 at 22 41 51@2x" src="https://user-images.githubusercontent.com/180686/83070799-499a9100-a06c-11ea-8e33-65e6a5cbe31e.png">
