### PR TITLE
Adjust VGWort implementation

### DIFF
--- a/Classes/Plugins/DownloadTool/DownloadTool.php
+++ b/Classes/Plugins/DownloadTool/DownloadTool.php
@@ -79,18 +79,12 @@ class DownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
                     'forceAbsoluteUrl' => true,
                 );
                 $title = $file['LABEL'] ? $file['LABEL'] : $file['ID'];
-                // Create a-tag without VG-Wort Redirect
-                if ($vgwort === FALSE) {
-                    // replace uid with URI to dpf API
-                    $markerArray['###FILE###'] = $this->cObj->typoLink($title, $conf);
-                    // Create a-tag with VG-Wort Redirect
-                } elseif(!empty($vgwort)) {
-                    $qucosaUrl = urlencode($this->cObj->typoLink_URL($conf));
-                    $confVgwort = array(
-                        'useCacheHash'     => 0,
-                        'parameter'        => $vgwort . $qucosaUrl . ' - piwik_download',
-                    );
-                    $markerArray['###FILE###'] = $this->cObj->typoLink($title, $confVgwort);
+                $markerArray['###FILE###'] = $this->cObj->typoLink($title, $conf);
+
+                if(!empty($vgwort)) {
+                    $markerArray['###VGWORT###'] = "<div class='div_vgwpixel' data-url='" . $vgwort . "'></div>";
+                } else {
+                    $markerArray['###VGWORT###'] = "";
                 }
                 $content .= $this->cObj->substituteMarkerArray($subpartArray['downloads'], $markerArray);
             }
@@ -140,7 +134,7 @@ class DownloadTool extends \Kitodo\Dlf\Common\AbstractPlugin
             } else {
                 $vgwortserver = 'http://vg08.met.vgwort.de/na/';
             }
-            return $vgworturl = $vgwortserver . $vgwortOpenKey . '?l=';
+            return $vgworturl = $vgwortserver . $vgwortOpenKey;
         }
         return FALSE;
     }

--- a/Classes/Plugins/DownloadTool/template.tmpl
+++ b/Classes/Plugins/DownloadTool/template.tmpl
@@ -1,13 +1,13 @@
 <!--
   This file is part of the TYPO3 CMS project.
- 
+
   It is free software; you can redistribute it and/or modify it under
   the terms of the GNU General Public License, either version 2
   of the License, or any later version.
- 
+
   For the full copyright and license information, please read the
   LICENSE.txt file that was distributed with this source code.
- 
+
   The TYPO3 project - inspiring people to share!
 -->
 <!-- ###TEMPLATE### -->
@@ -17,6 +17,7 @@
             <!-- ###DOWNLOADS### -->
             <li>
                 ###FILE###
+                ###VGWORT###
             </li>
             <!-- ###DOWNLOADS### -->
         </ul>

--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -105,6 +105,14 @@ $(document).ready(function() {
 
     inputWithOptions();
 
+    // Fetch VG Wort Zählpixel (if available) on download
+    $('.piwik_download').click(function(e) {
+        var vgwpixel = $(this).siblings(".div_vgwpixel").first();
+        if(vgwpixel.length > 0) {
+            vgwpixel.html("<img src='" + vgwpixel.attr('data-url') + "'  width='1' height='1' alt=''>");
+        }
+    });
+
 });
 
 var validateFormAndSave = function() {


### PR DESCRIPTION
This PR changes the handling of the VGWort implementation. The redirect for download links does not work anymore and the JS solution is encouraged. (-> https://tom.vgwort.de/Documents/pdfs/dokumentation/metis/DOC_Urhebermeldung.pdf)

I removed the VGWort traces from the download links and added a JS solution that fetches the Zählpixel on the click of the button. I tested the mechanism itself for documents with/without VGWort ID but I don't know if the actual counting works.

