### PR TITLE
Set explicit color for datepicker in the backoffice

### DIFF
--- a/Resources/Public/CSS/qucosabe.css
+++ b/Resources/Public/CSS/qucosabe.css
@@ -114,6 +114,9 @@ body {
     display: table;
 }
 
+.tx-dpf .datepicker {
+    color: #444;
+}
 
 ul[id^='ui-id-'].ui-autocomplete  {
     max-height: 200px;


### PR DESCRIPTION
The TYPO3 backend.css overrules the colors for the datepicker text so we have to make that explicit here.

**Before:**

![image](https://user-images.githubusercontent.com/180686/86782782-c94e4f00-c05f-11ea-83fa-7a9cc8384672.png)

**After:**

![image](https://user-images.githubusercontent.com/180686/86782815-d408e400-c05f-11ea-9ff5-45084566c921.png)

The better solution would be to reduce the `.classes` in the `datepicker` markup but that would be overkill when the whole backoffice moves to the frontend anyway. Also, I don't want to touch the minimized `bootstrap-datetimejs.min.js`.