### PR TITLE
Fix form crash on save with invalid values

### DIFF
--- a/Resources/Public/JavaScript/QucosaBe.js
+++ b/Resources/Public/JavaScript/QucosaBe.js
@@ -216,7 +216,7 @@ define(['jquery', 'TYPO3/CMS/Dpf/jquery-ui','twbs/bootstrap-datetimepicker'], fu
 
     var markPage = function(fieldset, error) {
         var pageId = fieldset.parent().attr('id');
-        var page = $('.tx-dpf-tabs li a[href=#' + pageId + ']');
+        var page = $('.tx-dpf-tabs li a[href="#' + pageId + '"]');
         if (error) {
             page.addClass('mandatory-error');
         } else {

--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -261,7 +261,7 @@ var hasMandatoryInputs = function(fieldset) {
 }
 var markPage = function(fieldset, error) {
     var pageId = fieldset.parent().attr('id');
-    var page = jQuery('.tx-dpf-tabs li a[href=#' + pageId + ']');
+    var page = jQuery('.tx-dpf-tabs li a[href="#' + pageId + '"]');
     if (error) {
         page.addClass('mandatory-error');
     } else {


### PR DESCRIPTION
When hitting the save button Javascript codes validates the form fields
and blocks the save button to dismiss the save action event. When form
validation errors are detected the form input tabs (pages) are marked
with an error icon (flame).

The selection expression was invalid causing the Javascript validation
function to crash. Subsequently the save action is not blocked and
invalid tabs are not marked.

Resolves https://jira.slub-dresden.de/browse/CMR-995
Resolves https://jira.slub-dresden.de/browse/CMR-954