### PR TITLE
[3.x] Remove fields when duplicating a document

### DIFF
--- a/Classes/Controller/DocumentController.php
+++ b/Classes/Controller/DocumentController.php
@@ -145,6 +145,10 @@ class DocumentController extends \EWW\Dpf\Controller\AbstractController
 
             $mods = new \EWW\Dpf\Helper\Mods($document->getXmlData());
             $mods->clearAllUrn();
+            $mods->removeDateIssued();
+            $mods->removeDOI();
+            $mods->removePPN();
+
             $newDocument->setXmlData($mods->getModsXml());
 
             $newDocument->setDocumentType($document->getDocumentType());

--- a/Classes/Helper/Mods.php
+++ b/Classes/Helper/Mods.php
@@ -203,4 +203,40 @@ class Mods
         }
     }
 
+    public function getDOI()
+    {
+        $doiNode = $this->getModsXpath()->query('./mods:identifier[@type="doi"]');
+
+        if ($doiNode->length > 0) {
+            return $doiNode->item(0)->nodeValue;
+        }
+        return null;
+    }
+
+    public function removeDOI()
+    {
+        $doiNode = $this->getModsXpath()->query('./mods:identifier[@type="doi"]');
+        if ($doiNode->length > 0) {
+            $doiNode->item(0)->parentNode->removeChild($doiNode->item(0));
+        }
+    }
+
+    public function getPPN()
+    {
+        $ppnNode = $this->getModsXpath()->query('./mods:identifier[@type="swb-ppn"]');
+
+        if ($ppnNode->length > 0) {
+            return $ppnNode->item(0)->nodeValue;
+        }
+        return null;
+    }
+
+    public function removePPN()
+    {
+        $ppnNode = $this->getModsXpath()->query('./mods:identifier[@type="swb-ppn"]');
+        if ($ppnNode->length > 0) {
+            $ppnNode->item(0)->parentNode->removeChild($ppnNode->item(0));
+        }
+    }
+
 }


### PR DESCRIPTION
This PR removes the date issued, DOI and PPN from a duplicated document.

I added helper functions to access the fields in the mods-xml. I'm only uncertain if the queries are stable enough. I guess they are for our purposes?

This closes #184.