### PR TITLE
[3.x] Improve erratic auto-scrolling in back office

### DIFF
--- a/Resources/Public/JavaScript/QucosaBe.js
+++ b/Resources/Public/JavaScript/QucosaBe.js
@@ -315,6 +315,8 @@ define(['jquery', 'TYPO3/CMS/Dpf/jquery-ui','twbs/bootstrap-datetimepicker'], fu
                 $('html, body').animate({scrollTop: element.position().top - height}, 400);
             })
 
+            group.find('input, textarea').first().focus();
+
             buttonFillOutServiceUrn();
             datepicker();
             addRemoveFileButton();

--- a/Resources/Public/JavaScript/QucosaBe.js
+++ b/Resources/Public/JavaScript/QucosaBe.js
@@ -309,10 +309,8 @@ define(['jquery', 'TYPO3/CMS/Dpf/jquery-ui','twbs/bootstrap-datetimepicker'], fu
                 .css({'display': 'none'})
                 .insertAfter($('fieldset[data-group="' + dataGroup + '"]').last());
 
-            var height = $(group).outerHeight(true) + 50;
-
             $(group).fadeIn(200, function(){
-                $('html, body').animate({scrollTop: element.position().top - height}, 400);
+                $('html, body').animate({scrollTop: group.position().top}, 400);
             })
 
             group.find('input, textarea').first().focus();

--- a/Resources/Public/JavaScript/QucosaBe.js
+++ b/Resources/Public/JavaScript/QucosaBe.js
@@ -309,12 +309,11 @@ define(['jquery', 'TYPO3/CMS/Dpf/jquery-ui','twbs/bootstrap-datetimepicker'], fu
                 .css({'display': 'none'})
                 .insertAfter($('fieldset[data-group="' + dataGroup + '"]').last());
 
-            var height = $('fieldset[data-group="' + dataGroup + '"]')
-                .last()
-                .outerHeight(true)
+            var height = $(group).outerHeight(true) + 50;
 
-            $('html, body')
-                .animate({scrollTop: element.offset().top - height}, 400, function() {$(group).fadeIn();});
+            $(group).fadeIn(200, function(){
+                $('html, body').animate({scrollTop: element.position().top - height}, 400);
+            })
 
             buttonFillOutServiceUrn();
             datepicker();
@@ -404,7 +403,7 @@ define(['jquery', 'TYPO3/CMS/Dpf/jquery-ui','twbs/bootstrap-datetimepicker'], fu
             if (element.error) {
                 var errorMsg = $('<div class="alert alert-danger alert-filloutservice-urn" role="alert"><span class="glyphicon glyphicon glyphicon-fire pull-right"></span>' + form_error_msg_filloutservice + '</div>');
                 errorMsg.insertAfter(group.find('legend'));
-                $("html, body").animate({scrollTop: group.offset().top}, 200);
+                $("html, body").animate({scrollTop: group.position().top}, 200);
             } else {
                 $('#qucosaid').val(element.qucosaId);
                 $('#qucosaUrn').val(element.value);
@@ -587,8 +586,8 @@ define(['jquery', 'TYPO3/CMS/Dpf/jquery-ui','twbs/bootstrap-datetimepicker'], fu
                 updatePrevNextButtons(newActivePage);
 
                 $('html, body').animate({
-                    scrollTop:$('.tx-dpf').offset().top
-                },'fast');
+                    scrollTop:$('.tx-dpf').position().top
+                }, 200);
             }
 
             e.preventDefault();

--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -326,6 +326,8 @@ var addGroup = function() {
             jQuery('html, body').animate({scrollTop: element.position().top - height}, 400);
         })
 
+        group.find('input, textarea').first().focus();
+
         buttonFillOutServiceUrn();
         datepicker();
         addRemoveFileButton();

--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -320,10 +320,9 @@ var addGroup = function() {
         jQuery(group).css({
             'display': 'none'
         }).insertAfter(jQuery('fieldset[data-group="' + dataGroup + '"]').last());
-        var height = jQuery(group).outerHeight(true) + 50;
 
         jQuery(group).fadeIn(200, function(){
-            jQuery('html, body').animate({scrollTop: element.position().top - height}, 400);
+            jQuery('html, body').animate({scrollTop: group.position().top}, 400);
         })
 
         group.find('input, textarea').first().focus();

--- a/Resources/Public/JavaScript/qucosa.js
+++ b/Resources/Public/JavaScript/qucosa.js
@@ -320,12 +320,12 @@ var addGroup = function() {
         jQuery(group).css({
             'display': 'none'
         }).insertAfter(jQuery('fieldset[data-group="' + dataGroup + '"]').last());
-        var height = jQuery('fieldset[data-group="' + dataGroup + '"]').last().outerHeight(true)
-        jQuery('html, body').animate({
-            scrollTop: element.offset().top - height
-        }, 400, function() {
-            jQuery(group).fadeIn();
-        });
+        var height = jQuery(group).outerHeight(true) + 50;
+
+        jQuery(group).fadeIn(200, function(){
+            jQuery('html, body').animate({scrollTop: element.position().top - height}, 400);
+        })
+
         buttonFillOutServiceUrn();
         datepicker();
         addRemoveFileButton();
@@ -411,7 +411,7 @@ var fillOutServiceUrn = function() {
         if (element.error) {
             var errorMsg = $('<div class="alert alert-danger alert-filloutservice-urn" role="alert"><span class="glyphicon glyphicon glyphicon-fire pull-right"></span>' + form_error_msg_filloutservice + '</div>');
             errorMsg.insertAfter(group.find('legend'));
-            $("html, body").animate({scrollTop: group.offset().top}, 200);
+            $("html, body").animate({scrollTop: group.position().top}, 200);
         } else {
             jQuery('#qucosaid').val(element.qucosaId);
             jQuery('#qucosaUrn').val(element.value);
@@ -687,8 +687,8 @@ var previousNextFormPage = function() {
             updatePrevNextButtons(newActivePage);
 
             $('html, body').animate({
-                scrollTop:$('.tx-dpf').offset().top
-            },'fast');
+                scrollTop:$('.tx-dpf').position().top
+            },200);
         }
 
         e.preventDefault();


### PR DESCRIPTION
This PR improves the mainly erratic scrolling in the back office.

I'm not 100% sure why there's a difference between the frontend and the back office. The JS was/is essentially the same.

**Improvement:**

The computation for the new scroll position was way too complex. The new scroll position was determined as an `offset()` from the `addGroup`-button taking the height of the group into account. We can simply scroll the to the added group. I flipped the animation from `scroll -> fadeIn` to `fadeIn -> scroll` in the process. ¯\\\_(ツ)\_/¯

This eliminates the `element.offset()` call which was the problem in the back office. While debugging I noticed that it produces relative values depending on the browser view port. I think that lead to problems in the back office and sometimes values got way too big/small (due to embedded frames?) so the page scrolled erratically to the top without apparent reasons. Therefore, I changed the other two occurrences of scrolling code from `offset()` to `position()` since that's the intention behind it.

As an added enhancement I focus the first input / textarea in the added group so it's possible to type right away.

**Cleanup:**

The single occurrence for the animation speed `'fast'` was changed to `200` as it maps to that value anyway and numbers are used throughout the rest of code.