### PR TITLE
Fix xlink namespace URI

### DIFF
--- a/Classes/Services/MetsExporter.php
+++ b/Classes/Services/MetsExporter.php
@@ -111,7 +111,7 @@ class MetsExporter
             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
             xmlns:foaf="http://xmlns.com/foaf/0.1/"
             xmlns:person="http://www.w3.org/ns/person#"
-            xmlns:xlink="https://www.w3.org/1999/xlink"
+            xmlns:xlink="http://www.w3.org/1999/xlink"
             xsi:schemaLocation="http://www.loc.gov/mods/v3 http://www.loc.gov/standards/mods/v3/mods-3-7.xsd"
             version="3.7">';
 


### PR DESCRIPTION
The proper XLink namespace for MODS documents is a HTTP URI. Using HTTPS
URIs results in invalid MODS. Also the namespace declaration is now
aligned with the duplicate declaration in the METS header.

https://jira.slub-dresden.de/browse/CMR-1017