### PR TITLE
[CMR-1038] Add COinS Plugin for output of bibliographical metadata

### DIFF
--- a/Classes/Plugins/Coins/Coins.php
+++ b/Classes/Plugins/Coins/Coins.php
@@ -96,7 +96,7 @@ class Coins extends \Kitodo\Dlf\Common\AbstractPlugin
         // -> https://archive.is/a0Hgs
 
         // Formal specification of COinS
-        $coins .= 'url_ver=Z39.88-2004';
+        $coins = 'url_ver=Z39.88-2004';
         $coins .= '&ctx_ver=Z39.88-2004';
 
         // TODO: Get the document type to differentiate info:ofi/fmt:kev:mtx:[book/journal] and rft.genre=[…]

--- a/Classes/Plugins/Coins/Coins.php
+++ b/Classes/Plugins/Coins/Coins.php
@@ -1,0 +1,250 @@
+<?php
+namespace EWW\Dpf\Plugins\Coins;
+
+/*
+ * This file is part of the TYPO3 CMS project.
+ *
+ * It is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU General Public License, either version 2
+ * of the License, or any later version.
+ *
+ * For the full copyright and license information, please read the
+ * LICENSE.txt file that was distributed with this source code.
+ *
+ * The TYPO3 project - inspiring people to share!
+ */
+
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Plugin 'DPF: Coins' for the 'dlf / dpf' extension.
+ *
+ * @author    Erik Sommer <erik.sommer@slub-dresden.de>
+ * @package    TYPO3
+ * @subpackage    tx_dpf
+ * @access    public
+ */
+class Coins extends \Kitodo\Dlf\Common\AbstractPlugin
+{
+    public $scriptRelPath = 'Classes/Plugins/Coins.php';
+
+    /**
+     * The main method of the PlugIn
+     *
+     * @access    public
+     *
+     * @param    string        $content: The PlugIn content
+     * @param    array        $conf: The PlugIn configuration
+     *
+     * @return    string        The content that is displayed on the website
+     */
+    public function main($content, $conf)
+    {
+        $this->init($conf);
+
+        // get the tx_dpf.settings too
+        // Flexform wins over TS
+        $dpfTSconfig = $GLOBALS['TSFE']->tmpl->setup['plugin.']['tx_dpf.'];
+        if (is_array($dpfTSconfig['settings.'])) {
+            \TYPO3\CMS\Core\Utility\ArrayUtility::mergeRecursiveWithOverrule($dpfTSconfig['settings.'], $this->conf, true, false);
+            $this->conf = $dpfTSconfig['settings.'];
+        }
+
+        $this->setCache(true);
+
+        $this->loadDocument();
+        if ($this->doc === null) {
+            return;
+        } else {
+            // Set default values if not set.
+            if (!isset($this->conf['rootline'])) {
+                $this->conf['rootline'] = 0;
+            }
+        }
+
+        $metadata = array();
+        $metadata = $this->doc->getTitleData($this->conf['pages']);
+
+        $metadata['_id'] = $this->doc->toplevelId;
+        if (empty($metadata)) {
+            if (TYPO3_DLOG) {
+                GeneralUtility::devLog(
+                    '[tx_dpf_metatags->main(' . $content . ', [data])] No metadata found for document with UID "' . $this->doc->uid . '"',
+                    'tx_dpf',
+                    SYSLOG_SEVERITY_WARNING,
+                    $conf
+                );
+            }
+            return;
+        }
+
+        return $this->generateCoins($metadata);
+    }
+
+    /**
+     * Prepares the coins <span> for output
+     *
+     * @access    protected
+     * @param    array        $metadata: The metadata array
+     *
+     * @return    string        The coins <span> ready for output
+     */
+     protected function generateCoins(array $metadata)
+    {
+
+        // The output follows the "Brief guide to Implementing OpenURL 1.0 Context Object for Journal Articles"
+        // -> https://archive.is/a0Hgs
+        //
+        // TODO: Get the document type to differentiate info:ofi/fmt:kev:mtx:[book/journal] and rft.genre=[…]
+
+        $coins = 'url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&rft.genre=unknown';
+
+        foreach ($metadata as $index_name => $values) {
+            if (preg_match("/^author[[:digit:]]+/", $index_name)) {
+                if (is_array($values)) {
+                    foreach ($values as $id => $value) {
+                        if ($value) {
+                            $coins .= '&rft.au=' . urlencode($value);
+                        }
+                    }
+                }
+                continue;
+            }
+
+            if (preg_match("/^publisher[[:digit:]]+/", $index_name)) {
+                if (is_array($values)) {
+                    foreach ($values as $id => $value) {
+                        if ($value) {
+                            $coins .= '&rft.pub=' . urlencode($value);
+                        }
+                    }
+                }
+                continue;
+            }
+
+            switch ($index_name) {
+                case 'record_id':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rfr_id=info:sid/qucosa.de:' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'urn':
+                case 'original_urn':
+                case 'series_urn':
+                case 'multivolume_urn':
+                case 'doi':
+                case 'original_doi':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft_id=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'isbn':
+                case 'original_isbn':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.isbn=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'issn':
+                case 'original_issn':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.issn=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'title':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.atitle=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'original_subtitle':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.stitle=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'original_title':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.jtitle=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'original_pages':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.spage=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'original_pages2':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.epage=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'issue':
+                case 'original_issue':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.issue=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'volume':
+                case 'original_volume':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.volume=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'original_corporation_publisher':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.pub=' . urlencode($values[0]);
+                    }
+                    break;
+
+                case 'place':
+                case 'original_place':
+                    if (is_array($values) && $values[0]) {
+                        if ($values[0]) {
+                            $coins .= '&rft.place=' . urlencode($values[0]);
+                        }
+                    }
+                    break;
+
+                case 'dateissued':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.date=' . urlencode($this->safelyFormatDate("Y/m/d", $values[0]));
+                    }
+                    break;
+
+                case 'language':
+                    if (is_array($values) && $values[0]) {
+                        $coins .= '&rft.language=' . urlencode($values[0]);
+                    }
+                    break;
+
+                default:
+                    break;
+            }
+        }
+
+        return '<span class="Z3988" title="' . $coins . '"></span>';
+    }
+
+    /**
+     * Format given date with given format, assuming the input date format is
+     * parseable by strtotime(). If the input string has a length of 4 (like
+     * "1989") the string is returned as is, without formatting.
+     *
+     * @param String $format Target string format
+     * @param String $date   Date string to format
+     *
+     * @return Formatted date
+     */
+     protected function safelyFormatDate($format, $date)
+    {
+        return (strlen($date) == 4) ? $date : date($format, strtotime($date));
+    }
+}

--- a/Classes/Plugins/Coins/Coins.php
+++ b/Classes/Plugins/Coins/Coins.php
@@ -94,10 +94,14 @@ class Coins extends \Kitodo\Dlf\Common\AbstractPlugin
 
         // The output follows the "Brief guide to Implementing OpenURL 1.0 Context Object for Journal Articles"
         // -> https://archive.is/a0Hgs
-        //
-        // TODO: Get the document type to differentiate info:ofi/fmt:kev:mtx:[book/journal] and rft.genre=[…]
 
-        $coins = 'url_ver=Z39.88-2004&ctx_ver=Z39.88-2004&rft_val_fmt=info%3Aofi%2Ffmt%3Akev%3Amtx%3Ajournal&rft.genre=unknown';
+        // Formal specification of COinS
+        $coins .= 'url_ver=Z39.88-2004';
+        $coins .= '&ctx_ver=Z39.88-2004';
+
+        // TODO: Get the document type to differentiate info:ofi/fmt:kev:mtx:[book/journal] and rft.genre=[…]
+        $coins .= '&rft_val_fmt='. urlencode('info:ofi/fmt:kev:mtx:journal');
+        $coins .= '&rft.genre=unknown';
 
         foreach ($metadata as $index_name => $values) {
             if (preg_match("/^author[[:digit:]]+/", $index_name)) {

--- a/Classes/Plugins/Coins/flexform.xml
+++ b/Classes/Plugins/Coins/flexform.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<!--
+  This file is part of the TYPO3 CMS project.
+
+  It is free software; you can redistribute it and/or modify it under
+  the terms of the GNU General Public License, either version 2
+  of the License, or any later version.
+
+  For the full copyright and license information, please read the
+  LICENSE.txt file that was distributed with this source code.
+
+  The TYPO3 project - inspiring people to share!
+-->
+<T3DataStructure>
+    <meta>
+        <langDisable>1</langDisable>
+    </meta>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>LLL:EXT:dpf/Resources/Private/Language/locallang.xlf:tt_content.pi_flexform.sheet_general
+                    </sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <pages>
+                        <TCEforms>
+                            <exclude>1</exclude>
+                            <label>LLL:EXT:lang/locallang_general.xml:LGL.startingpoint</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>db</internal_type>
+                                <allowed>pages</allowed>
+                                <size>1</size>
+                                <maxitems>1</maxitems>
+                                <minitems>1</minitems>
+                                <wizards>
+                                    <suggest>
+                                        <type>suggest</type>
+                                    </suggest>
+                                </wizards>
+                            </config>
+                        </TCEforms>
+                    </pages>
+                </el>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -82,3 +82,15 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['dpf_relatedl
     'dpf'
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue('dpf_relatedlisttool', 'FILE:EXT:dpf/Classes/Plugins/RelatedListTool/flexform.xml');
+
+// Plugin "Coins".
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_excludelist']['dpf_coins'] = 'layout,select_key,pages,recursive';
+$GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist']['dpf_coins'] = 'pi_flexform';
+
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
+    array('LLL:EXT:dpf/Resources/Private/Language/locallang.xlf:tt_content.dpf_coins',
+        'dpf_coins'),
+    'list_type',
+    'dpf'
+);
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue('dpf_coins', 'FILE:EXT:dpf/Classes/Plugins/Coins/flexform.xml');

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -718,6 +718,10 @@ Sächsische Landesbibliothek- Staats- und Universitätsbibliothek Dresden
 			<source>DPF: RelatedListTool</source>
 			<target>DPF: RelatedList Tool</target>
 		</trans-unit>
+		<trans-unit id="tt_content.dpf_coins" approved="yes">
+			<source>DPF: Coins</source>
+			<target>DPF: Coins</target>
+		</trans-unit>
 		<trans-unit id="tt_content.pi_flexform.apiPid" approved="yes">
 			<source>API Pid</source>
 			<target>API Pid</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -524,6 +524,9 @@ Date: ###DATE###
 		<trans-unit id="tt_content.dpf_relatedlisttool">
 			<source>DPF: RelatedListTool</source>
 		</trans-unit>
+		<trans-unit id="tt_content.dpf_coins">
+			<source>DPF: Coins</source>
+		</trans-unit>
 		<trans-unit id="tt_content.pi_flexform.apiPid">
 			<source>API Pid</source>
 		</trans-unit>

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -86,4 +86,8 @@ $overrideSetup = 'plugin.tx_dpf_downloadtool.userFunc = EWW\Dpf\Plugins\Download
 $overrideSetup = 'plugin.tx_dpf_relatedlisttool.userFunc = EWW\Dpf\Plugins\RelatedListTool\RelatedListTool->main';
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript($_EXTKEY, 'setup', $overrideSetup);
 
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43($_EXTKEY, 'Classes/Plugins/Coins/Coins.php', '_coins', 'list_type', true);
+$overrideSetup = 'plugin.tx_dpf_coins.userFunc = EWW\Dpf\Plugins\Coins\Coins->main';
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTypoScript($_EXTKEY, 'setup', $overrideSetup);
+
 $TYPO3_CONF_VARS['BE']['AJAX']['AjaxDocumentFormController:fieldAction'] = 'EXT:Dpf/Classes/Controller/AjaxDocumentFormController.php:AjaxDocumentFormController->fieldAction';


### PR DESCRIPTION
This PR adds a [COinS](https://en.wikipedia.org/wiki/COinS) Plugin to the Extension which can be used to output standardized bibliographical metadata to the landing page. This enables reference management software to pick up the data for later use.

> <img width="736" alt="Screen Shot 2021-01-18 at 22 16 27" src="https://user-images.githubusercontent.com/180686/104963813-99531180-59db-11eb-96b2-7c4ff6a0dda4.png">

Quick test with the document https://nbn-resolving.org/urn:nbn:de:bsz:14-qucosa2-347767

**Without COinS-Plugin enabled:**

> <img width="330" alt="Screen Shot 2021-01-18 at 22 23 22" src="https://user-images.githubusercontent.com/180686/104963954-d4eddb80-59db-11eb-8268-870481ad9bf0.png">

**With COinS-Plugin enabled:**

> <img width="353" alt="mit_coins" src="https://user-images.githubusercontent.com/180686/104964013-f18a1380-59db-11eb-9f33-28b6ac76389d.png">


 