### PR TITLE
Adds CSRF form tokens for forms

### DIFF
--- a/Classes/Controller/AbstractDocumentFormController.php
+++ b/Classes/Controller/AbstractDocumentFormController.php
@@ -22,7 +22,7 @@ use EWW\Dpf\Helper\FormDataReader;
 use EWW\Dpf\Domain\Workflow\DocumentWorkflow;
 use EWW\Dpf\Services\Email\Notifier;
 use EWW\Dpf\Domain\Model\DepositLicenseLog;
-
+use Exception;
 
 /**
  * DocumentFormController
@@ -176,7 +176,12 @@ abstract class AbstractDocumentFormController extends AbstractController
             $formDataReader = $this->objectManager->get(FormDataReader::class);
             $formDataReader->setFormData($documentData);
 
-            $docForm                             = $formDataReader->getDocumentForm();
+            $docForm = $formDataReader->getDocumentForm();
+
+            if (!$docForm->hasValidCsrfToken()) {
+                throw new Exception("Invalid CSRF Token");
+            }
+
             $requestArguments['newDocumentForm'] = $docForm;
 
             $docTypeUid = $documentData['type'];
@@ -335,6 +340,10 @@ abstract class AbstractDocumentFormController extends AbstractController
             $formDataReader = $this->objectManager->get(FormDataReader::class);
             $formDataReader->setFormData($documentData);
             $docForm = $formDataReader->getDocumentForm();
+
+            if (!$docForm->hasValidCsrfToken()) {
+                throw new Exception("Invalid CSRF Token");
+            }
 
             $requestArguments['documentForm'] = $docForm;
 

--- a/Classes/Domain/Model/DocumentForm.php
+++ b/Classes/Domain/Model/DocumentForm.php
@@ -1,5 +1,10 @@
 <?php
+
 namespace EWW\Dpf\Domain\Model;
+
+use Exception;
+use TypeError;
+use TYPO3\CMS\Core\FormProtection\FormProtectionFactory;
 
 /*
  * This file is part of the TYPO3 CMS project.
@@ -16,6 +21,11 @@ namespace EWW\Dpf\Domain\Model;
 
 class DocumentForm extends AbstractFormElement
 {
+
+    /**
+     * @var string CSRF token for this form
+     */
+    private $csrfToken;
 
     /**
      *
@@ -86,6 +96,59 @@ class DocumentForm extends AbstractFormElement
      * @var string
      */
     protected $comment = '';
+
+    /**
+     * Assign and persist CSRF token for later form validation.
+     *
+     * @param string $csrfToken
+     */
+    public function generateCsrfToken()
+    {
+        $formProtection = FormProtectionFactory::get();
+        $this->csrfToken = $formProtection->generateToken('DocumentForm', 'construct', 'DocumentForm');
+        $formProtection->persistSessionToken();
+    }
+
+    /**
+     * Set the CSRF token for this form
+     *
+     * Used when creating a new instance from request form data.
+     *
+     * @param string $csrfToken CSRF token to set
+     * @throws Exception if the given string is empty.
+     * @throws TypeError if the given string is null
+     */
+    public function setCsrfToken(string $csrfToken)
+    {
+        if ($csrfToken === "")
+        {
+            throw new Exception("A forms CSRF token cannot be empty");
+        }
+        $this->csrfToken = $csrfToken;
+    }
+
+
+    /**
+     * Returns the CSRF token of this form
+     *
+     * @return string CSRF token for this form
+     */
+    public function getCsrfToken()
+    {
+        return $this->csrfToken;
+    }
+
+
+    /**
+     * Validates this forms assigned CSRF token with token stored in the TYPO3 session.
+     *
+     * @return bool True, is CSRF token is considered valid. False if the token is invalid or missing.
+     */
+    public function hasValidCsrfToken()
+    {
+        $formProtection = FormProtectionFactory::get();
+        return $formProtection->validateToken($this->csrfToken, 'DocumentForm', 'construct', 'DocumentForm');
+    }
 
     /**
      *
@@ -268,5 +331,4 @@ class DocumentForm extends AbstractFormElement
     {
         $this->comment = $comment;
     }
-
 }

--- a/Classes/Helper/DocumentMapper.php
+++ b/Classes/Helper/DocumentMapper.php
@@ -109,6 +109,7 @@ class DocumentMapper
     public function getDocumentForm(Document $document, $generateEmptyFields = true)
     {
         $documentForm = new \EWW\Dpf\Domain\Model\DocumentForm();
+        $documentForm->generateCsrfToken();
         $documentForm->setUid($document->getDocumentType()->getUid());
         $documentForm->setDisplayName($document->getDocumentType()->getDisplayName());
         $documentForm->setName($document->getDocumentType()->getName());
@@ -370,7 +371,7 @@ class DocumentMapper
         $document->setReservedObjectIdentifier($documentForm->getFedoraPid());
 
         $document->setValid($documentForm->getValid());
-        
+
         if ($documentForm->getComment()) {
             $document->setComment($documentForm->getComment());
         }

--- a/Classes/Helper/FormDataReader.php
+++ b/Classes/Helper/FormDataReader.php
@@ -324,6 +324,7 @@ class FormDataReader
         $fields = $this->getFields();
 
         $documentForm = new \EWW\Dpf\Domain\Model\DocumentForm();
+        $documentForm->setCsrfToken($this->formData['csrfToken']);
         $documentForm->setUid($this->documentType->getUid());
         $documentForm->setDisplayName($this->documentType->getDisplayName());
         $documentForm->setName($this->documentType->getName());

--- a/Resources/Private/Partials/DocumentForm/New.html
+++ b/Resources/Private/Partials/DocumentForm/New.html
@@ -13,6 +13,7 @@
     -->
 </f:comment>
 <f:form action="create" class="document-form-main" id="new-document-form" name="documentData" object="{documentData}" enctype="multipart/form-data" noCacheHash="TRUE">
+    <f:form.hidden id="csrfToken" property="csrfToken" value="{documentForm.csrfToken}"/>
     <f:form.hidden property="type" value="{documentForm.uid}"/>
     <f:form.hidden id="fedorapid" property="fedoraPid" value="{documentForm.fedoraPid}"/>
     <f:form.hidden id="primaryUrn" property="primaryUrn" value="{documentForm.primaryUrn}"/>

--- a/Resources/Private/Templates/DocumentForm/New.html
+++ b/Resources/Private/Templates/DocumentForm/New.html
@@ -19,7 +19,7 @@
     <h2>
         <f:translate key="documentForm.new.header" arguments="{0: '{documentForm.displayName}'}"/>
     </h2>
-    <f:render partial="DocumentForm/New" arguments="{documentForm:documentForm, fisPersId: fisPersId}"/>
+    <f:render partial="DocumentForm/New" arguments="{_all}"/>
 
     <f:form action="cancel" name="cancelData" object="{}" enctype="multipart/form-data" noCacheHash="TRUE">
         <f:form.button name="cancel" id="cancel" class="btn btn-sm btn-outline-secondary">

--- a/Resources/Private/Templates/DocumentFormBackoffice/Edit.html
+++ b/Resources/Private/Templates/DocumentFormBackoffice/Edit.html
@@ -70,6 +70,7 @@
                 data-activegroupindex: '{activeGroupIndex}',
                 data-addcurrentfeuser: '{addCurrentFeUser}',
                 data-fispersid: '{fisPersId}'}">
+        <f:form.hidden id="csrfToken" property="csrfToken" value="{documentForm.csrfToken}"/>
         <f:form.hidden property="type" value="{documentForm.uid}"/>
         <f:form.hidden property="documentUid" value="{documentForm.documentUid}"/>
         <f:form.hidden id="fedorapid" property="fedoraPid" value="{documentForm.fedoraPid}"/>


### PR DESCRIPTION
Tokens are handled by EWW\Dpf\Domain\Model\DocumentForm. There are four
methods to generate, assign, return and validate the form instances CSRF
token:

- generateCsrfToken()
- setCsrfToken(string $csrfToken)
- getCsrfToken()
- hasValidCsrfToken()

Token assignment from a request form data is handled in
EWW\Dpf\Helper\FormDataReader::getDocumentForm. If the CSRF token is
empty or missing an exception gets thrown.

Token generation is handled in
EWW\Dpf\Helper\DocumentMapper::getDocumentForm. If a new DocumentForm is
generated from a Document a new CSRF token is generated.