### PR TITLE
fix position of alerts

### DIFF
--- a/Resources/Public/CSS/qucosa.css
+++ b/Resources/Public/CSS/qucosa.css
@@ -433,7 +433,7 @@ ul.error-files-backbutton li {
     list-style: none;
 }
 
-.tx-dpf form .alert {
+.tx-dpf form .alert-danger {
     position: relative;
     top: 60px;
 }


### PR DESCRIPTION
Warnings are displaced to lower position in order not to be covered by the navigation menu. This causes warnings to cover the actual input fields, making input impossible. This fix causes the position shift to be applied only to the dangerous warnings on top and allows undisturbed input.