### PR TITLE
Close response content stream after HTTP request

### DIFF
--- a/Classes/Command/IndexByFile.php
+++ b/Classes/Command/IndexByFile.php
@@ -175,6 +175,13 @@ class IndexByFile extends AbstractIndexCommand
         if (preg_match('/^(text|application)\/(.*)xml(.*)$/', $contentType)) {
             try {
                 $this->indexXml($response->getBody()->getContents());
+
+                // Closing content stream and killing the response variable.
+                // This should actually be happening when leaving the function
+                // scope. But there are weird issues with open files from Guzzle magic.
+                $response->getBody()->close();
+                unset($response);
+
                 $io->writeln("OK");
                 return TRUE;
             } catch (\Exception $e) {


### PR DESCRIPTION
Guzzle HTTP library has issues releasing the content streams and curl connection streams after an HTTP requests. This commit tries to force the release of the stream and thus the system file handles.

See https://github.com/guzzle/guzzle/issues/1927

Resolves kitodo-publication/issues#1945