### PR TITLE
Remove VGWort tracking from DownloadTool

### DIFF
--- a/Classes/Plugins/DownloadTool/DownloadTool.php
+++ b/Classes/Plugins/DownloadTool/DownloadTool.php
@@ -14,7 +14,6 @@ namespace EWW\Dpf\Plugins\DownloadTool;
  * The TYPO3 project - inspiring people to share!
  */
 
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Plugin 'DPF: DownloadTool' for the 'dlf / dpf' extension.
@@ -67,8 +66,6 @@ class DownloadTool extends \EWW\Dpf\Common\AbstractPlugin
         $subpartArray['downloads'] = $this->templateService->getSubpart($this->template, '###DOWNLOADS###');
         // Show all PDF documents in download filegroup
         $attachments = $this->getAttachments();
-        // Get VG-Wort-Url
-        $vgwort = $this->getVGWortUrl();
         $content = '';
         if (is_array($attachments)) {
             foreach ($attachments as $id => $file) {
@@ -81,11 +78,6 @@ class DownloadTool extends \EWW\Dpf\Common\AbstractPlugin
                 $title = $file['LABEL'] ? $file['LABEL'] : $file['ID'];
                 $markerArray['###FILE###'] = $this->cObj->typoLink($title, $conf);
 
-                if(!empty($vgwort)) {
-                    $markerArray['###VGWORT###'] = "<div class='div_vgwpixel' data-url='" . $vgwort . "'></div>";
-                } else {
-                    $markerArray['###VGWORT###'] = "";
-                }
                 $content .= $this->templateService->substituteMarkerArray($subpartArray['downloads'], $markerArray);
             }
         }
@@ -121,21 +113,4 @@ class DownloadTool extends \EWW\Dpf\Common\AbstractPlugin
         return $attachments;
     }
 
-    protected function getVGWortUrl()
-    {
-        // Get VG-Wort-OpenKey for document
-        $this->doc->mets->registerXPathNamespace("slub", 'http://slub-dresden.de/');
-        $xPath = '//slub:info/slub:vgwortOpenKey';
-        $vgwortOpenKey = $this->doc->mets->xpath($xPath)[0];
-
-        if (!empty($vgwortOpenKey) or $vgwortOpenKey != FALSE ) {
-            if (GeneralUtility::getIndpEnv('TYPO3_SSL')) {
-                $vgwortserver = 'https://ssl-vg03.met.vgwort.de/na/';
-            } else {
-                $vgwortserver = 'http://vg08.met.vgwort.de/na/';
-            }
-            return $vgworturl = $vgwortserver . $vgwortOpenKey;
-        }
-        return FALSE;
-    }
 }

--- a/Classes/Plugins/DownloadTool/template.tmpl
+++ b/Classes/Plugins/DownloadTool/template.tmpl
@@ -17,7 +17,6 @@
             <!-- ###DOWNLOADS### -->
             <li>
                 ###FILE###
-                ###VGWORT###
             </li>
             <!-- ###DOWNLOADS### -->
         </ul>


### PR DESCRIPTION
SLUB no longer tracks VGWort; 3.x branch already dropped it (035d91f0). Removes getVGWortUrl(), its call site/marker in DownloadTool.php, and the ###VGWORT### slot in template.tmpl.

Also fixes the PHPStan 2.2.8 notEqual.alwaysFalse finding that was blocking the dependabot phpstan bump PR (#368) — moot now that the whole method is gone.